### PR TITLE
Tango backend attempt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dev = [
     "pydata-sphinx-theme>=0.12",
     "pytest",
     "pytest-cov",
+    "pytest-mock",
+    "pytest-asyncio",
     "ruff",
     "sphinx-autobuild",
     "sphinx-copybutton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "numpy",
     "pydantic",
     "pvi~=0.9.0",
+    "pytango",
     "softioc",
 ]
 dynamic = ["version"]

--- a/src/fastcs/backends/__init__.py
+++ b/src/fastcs/backends/__init__.py
@@ -1,4 +1,5 @@
 from .asyncio_backend import AsyncioBackend
 from .epics.backend import EpicsBackend
+from .tango.backend import TangoBackend
 
-__all__ = ["EpicsBackend", "AsyncioBackend"]
+__all__ = ["EpicsBackend", "AsyncioBackend", "TangoBackend"]

--- a/src/fastcs/backends/tango/backend.py
+++ b/src/fastcs/backends/tango/backend.py
@@ -1,0 +1,11 @@
+from fastcs.mapping import Mapping
+
+from .dsr import TangoDSR
+
+
+class TangoBackend:
+    def __init__(self, mapping: Mapping):
+        self._mapping = mapping
+
+    def get_dsr(self) -> TangoDSR:
+        return TangoDSR(self._mapping)

--- a/src/fastcs/backends/tango/dsr.py
+++ b/src/fastcs/backends/tango/dsr.py
@@ -29,6 +29,8 @@ def _wrap_updater_fget(
     attr_name: str, attribute: AttrR, controller: BaseController
 ) -> Callable[[Any], Any]:
     async def fget(tango_device: Device):
+        assert attribute.updater is not None
+
         await attribute.updater.update(controller, attribute)
         tango_device.info_stream(f"called fget method: {attr_name}")
         return attribute.get()
@@ -56,6 +58,8 @@ def _wrap_updater_fset(
     attr_name: str, attribute: AttrW, controller: BaseController
 ) -> Callable[[Any, Any], Any]:
     async def fset(tango_device: Device, val):
+        assert attribute.sender is not None
+
         await attribute.sender.put(controller, attribute, val)
         tango_device.info_stream(f"called fset method: {attr_name}")
 

--- a/src/fastcs/backends/tango/dsr.py
+++ b/src/fastcs/backends/tango/dsr.py
@@ -1,0 +1,222 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from types import MethodType
+from typing import Any
+
+import tango
+from tango import AttrWriteType, Database, DbDevInfo, DevState, server
+
+from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW
+from fastcs.backend import (
+    _link_attribute_sender_class,
+    _link_single_controller_put_tasks,
+)
+from fastcs.controller import BaseController
+from fastcs.datatypes import Float
+from fastcs.mapping import Mapping
+
+
+@dataclass
+class TangoDSROptions:
+    dev_name: str = "MY/DEVICE/NAME"
+    dev_class: str = "FAST_CS_DEVICE"
+    dsr_instance: str = "MY_SERVER_INSTANCE"
+    debug: bool = False
+
+
+def _wrap_updater_fget(
+    attr_name: str, attribute: AttrR, controller: BaseController
+) -> Callable[[Any], Any]:
+    async def fget(self):
+        await attribute.updater.update(controller, attribute)
+        self.info_stream(f"called fget method: {attr_name}")
+        return attribute.get()
+
+    return fget
+
+
+def _tango_polling_period(attribute: AttrR) -> int:
+    if attribute.updater is not None:
+        # Convert to integer milliseconds
+        return int(attribute.updater.update_period * 1000)
+
+    return -1  # `tango.server.attribute` default for `polling_period`
+
+
+def _tango_display_format(attribute: Attribute) -> str:
+    match attribute.datatype:
+        case Float(prec):
+            return f"%.{prec}"
+
+    return "6.2f"  # `tango.server.attribute` default for `format`
+
+
+def _wrap_updater_fset(
+    attr_name: str, attribute: AttrW, controller: BaseController
+) -> Callable[[Any, Any], Any]:
+    async def fset(self, val):
+        await attribute.sender.put(controller, attribute, val)
+        self.info_stream(f"called fset method: {attr_name}")
+
+    return fset
+
+
+def _collect_dev_attributes(mapping: Mapping) -> dict[str, Any]:
+    collection: dict[str, Any] = {}
+    for single_mapping in mapping.get_controller_mappings():
+        path = single_mapping.controller.path
+
+        for attr_name, attribute in single_mapping.attributes.items():
+            attr_name = attr_name.title().replace("_", "")
+            d_attr_name = f"{'_'.join(path)}_{attr_name}" if path else attr_name
+
+            match attribute:
+                case AttrRW():
+                    collection[d_attr_name] = server.attribute(
+                        label=d_attr_name,
+                        dtype=attribute.datatype.dtype,
+                        fget=_wrap_updater_fget(
+                            attr_name, attribute, single_mapping.controller
+                        ),
+                        fset=_wrap_updater_fset(
+                            attr_name, attribute, single_mapping.controller
+                        ),
+                        access=AttrWriteType.READ_WRITE,
+                        format=_tango_display_format(attribute),
+                        polling_period=_tango_polling_period(attribute),
+                    )
+                case AttrR():
+                    collection[d_attr_name] = server.attribute(
+                        label=d_attr_name,
+                        dtype=attribute.datatype.dtype,
+                        access=AttrWriteType.READ,
+                        fget=_wrap_updater_fget(
+                            attr_name, attribute, single_mapping.controller
+                        ),
+                        format=_tango_display_format(attribute),
+                        polling_period=_tango_polling_period(attribute),
+                    )
+                case AttrW():
+                    collection[d_attr_name] = server.attribute(
+                        label=d_attr_name,
+                        dtype=attribute.datatype.dtype,
+                        access=AttrWriteType.WRITE,
+                        fset=_wrap_updater_fset(
+                            attr_name, attribute, single_mapping.controller
+                        ),
+                        format=_tango_display_format(attribute),
+                    )
+
+    return collection
+
+
+def _wrap_command_f(
+    method_name: str, method: Callable, controller: BaseController
+) -> Callable[..., Awaitable[None]]:
+    async def _dynamic_f(self) -> None:
+        self.info_stream(f"called {controller} f method: {method_name}")
+        return await MethodType(method, controller)()
+
+    _dynamic_f.__name__ = method_name
+    return _dynamic_f
+
+
+def _collect_dev_commands(mapping: Mapping) -> dict[str, Any]:
+    collection: dict[str, Any] = {}
+    for single_mapping in mapping.get_controller_mappings():
+        path = single_mapping.controller.path
+
+        for name, method in single_mapping.command_methods.items():
+            cmd_name = name.title().replace("_", "")
+            d_cmd_name = f"{'_'.join(path)}_{cmd_name}" if path else cmd_name
+            collection[d_cmd_name] = server.command(
+                f=_wrap_command_f(d_cmd_name, method.fn, single_mapping.controller)
+            )
+
+    return collection
+
+
+def _collect_dev_properties(mapping: Mapping) -> dict[str, Any]:
+    collection: dict[str, Any] = {}
+    return collection
+
+
+def _collect_dev_init(mapping: Mapping) -> dict[str, Callable]:
+    async def init_device(self):
+        await server.Device.init_device(self)
+        self.set_state(DevState.ON)
+        await mapping.controller.connect()
+
+    return {"init_device": init_device}
+
+
+def _collect_dev_flags(mapping: Mapping) -> dict[str, Any]:
+    collection: dict[str, Any] = {}
+
+    collection["green_mode"] = tango.GreenMode.Asyncio
+
+    return collection
+
+
+def _collect_dsr_args(options: TangoDSROptions) -> list[str]:
+    args = []
+
+    if options.debug:
+        args.append("-v4")
+
+    return args
+
+
+class TangoDSR:
+    def __init__(self, mapping: Mapping):
+        self._mapping = mapping
+
+    def _link_process_tasks(self) -> None:
+        for single_mapping in self._mapping.get_controller_mappings():
+            _link_single_controller_put_tasks(single_mapping)
+            _link_attribute_sender_class(single_mapping)
+
+    def run(self, options: TangoDSROptions | None = None) -> None:
+        if options is None:
+            options = TangoDSROptions()
+
+        self._link_process_tasks()
+
+        class_dict: dict = {
+            **_collect_dev_attributes(self._mapping),
+            **_collect_dev_commands(self._mapping),
+            **_collect_dev_properties(self._mapping),
+            **_collect_dev_init(self._mapping),
+            **_collect_dev_flags(self._mapping),
+        }
+
+        class_bases = (server.Device,)
+        pytango_class = type(options.dev_class, class_bases, class_dict)
+        register_dev(options.dev_name, options.dev_class, options.dsr_instance)
+
+        dsr_args = _collect_dsr_args(options)
+
+        server.run(
+            (pytango_class,),
+            [options.dev_class, options.dsr_instance, *dsr_args],
+        )
+
+
+def register_dev(dev_name: str, dev_class: str, dsr_instance: str) -> None:
+    dsr_name = f"{dev_class}/{dsr_instance}"
+    dev_info = DbDevInfo()
+    dev_info.name = dev_name
+    dev_info._class = dev_class
+    dev_info.server = dsr_name
+
+    db = Database()
+    db.delete_device(dev_name)  # Remove existing device entry
+    db.add_device(dev_info)
+
+    # Validate registration by reading
+    read_dev_info = db.get_device_info(dev_info.name)
+
+    print("Registered on Tango Database:")
+    print(f" - Device: {read_dev_info.name}")
+    print(f" - Class: {read_dev_info.class_name}")
+    print(f" - Device server: {read_dev_info.ds_full_name}")

--- a/tests/backends/tango/test_dsr.py
+++ b/tests/backends/tango/test_dsr.py
@@ -1,0 +1,34 @@
+import pytest
+from pytest_mock import MockerFixture
+from tango._tango import AttrWriteType, CmdArgType
+
+from fastcs.backends.tango.dsr import _collect_dev_attributes, _collect_dev_commands
+
+
+def test_collect_attributes(mapping):
+    attributes = _collect_dev_attributes(mapping)
+
+    # Check that attributes are created and of expected type
+    assert list(attributes.keys()) == [
+        "ReadInt",
+        "ReadString",
+        "ReadWriteFloat",
+        "WriteBool",
+    ]
+    assert attributes["ReadInt"].attr_write == AttrWriteType.READ
+    assert attributes["ReadInt"].attr_type == CmdArgType.DevLong64
+    assert attributes["ReadString"].attr_write == AttrWriteType.READ
+    assert attributes["ReadString"].attr_type == CmdArgType.DevString
+    assert attributes["ReadWriteFloat"].attr_write == AttrWriteType.READ_WRITE
+    assert attributes["ReadWriteFloat"].attr_type == CmdArgType.DevDouble
+    assert attributes["WriteBool"].attr_write == AttrWriteType.WRITE
+    assert attributes["WriteBool"].attr_type == CmdArgType.DevBoolean
+
+
+@pytest.mark.asyncio
+async def test_collect_commands(mapping, mocker: MockerFixture):
+    commands = _collect_dev_commands(mapping)
+
+    # Check that command is created and it can be called
+    assert list(commands.keys()) == ["Go"]
+    await commands["Go"](mocker.MagicMock())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,12 @@ import os
 
 import pytest
 
+from fastcs.attributes import AttrR, AttrRW, AttrW
+from fastcs.controller import Controller
+from fastcs.datatypes import Bool, Float, Int, String
+from fastcs.mapping import Mapping
+from fastcs.wrappers import command
+
 # Prevent pytest from catching exceptions when debugging in vscode so that break on
 # exception works correctly (see: https://github.com/pytest-dev/pytest/issues/7409)
 if os.getenv("PYTEST_RAISE", "0") == "1":
@@ -13,3 +19,24 @@ if os.getenv("PYTEST_RAISE", "0") == "1":
     @pytest.hookimpl(tryfirst=True)
     def pytest_internalerror(excinfo):
         raise excinfo.value
+
+
+class TestController(Controller):
+    read_int: AttrR = AttrR(Int())
+    read_write_float: AttrRW = AttrRW(Float())
+    write_bool: AttrW = AttrW(Bool())
+    read_string: AttrR = AttrR(String())
+
+    @command()
+    async def go(self):
+        pass
+
+
+@pytest.fixture
+def controller():
+    return TestController()
+
+
+@pytest.fixture
+def mapping(controller):
+    return Mapping(controller)


### PR DESCRIPTION
## Fastcs tango backend
- I have made forks of Martin’s demo and fastcs respectively 
  - https://github.com/marcelldls/FastCS
  - https://github.com/marcelldls/demo-fast-cs
- Gary has given an initial review and I have included his feedback

You can run the demo by:
- Checking out the tango branches of fastcs and the demo
- Spinning up a tango control system 
  - `yum install podman-compose`
  - `podman-compose up` from the demo directory
- From the dev container
  - Start the tickit device via the vscode debug launch
  - Start tango device server by running `test-demo` from the command line

You can interact with the device in the following manners:
- Via an interactive python terminal:
  - Run `itango3` from the dev container
  - Create device proxy: `dev = DeviceProxy("my/device/name")`
  - then you can use auto complete on dev (e.g. `dev.get_attribute_list()` or `dev.RampRate`)
- Via Jive GUI database administation application
  - `podman pull andygotz/tango-jive:7.19` 
  - `podman run -ti --rm -e DISPLAY=$DISPLAY -e TANGO_HOST=localhost:10000 -v /tmp/.X11-unix:/tmp/.X11-unix --security-opt label=type:container_runtime_t --net=host andygotz/tango-jive:7.19`
  - You may first need to run `xhost +local:podman` to get a window
  - Device interaction via the built in ATKPanel GUI can then be done by right clicking on the device (via the tree) in Jive and selecting `monitor device`
- Alternatively via a Taurus gui I scraped together (`python taurus_gui.py`  from outside dev container) (Its not programmatic, I just made it out of interest to get something similar to the epics gui – the observatory science team claim Taurus and Taranta are the popular Tango gui frameworks)
