### PR TITLE
String DataType

### DIFF
--- a/src/fastcs/backends/epics/gui.py
+++ b/src/fastcs/backends/epics/gui.py
@@ -16,6 +16,7 @@ from pvi.device import (
     SignalRW,
     SignalW,
     SignalX,
+    TextFormat,
     TextRead,
     TextWrite,
     Tree,
@@ -23,7 +24,7 @@ from pvi.device import (
 )
 
 from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW
-from fastcs.datatypes import Bool, DataType, Float, Int
+from fastcs.datatypes import Bool, DataType, Float, Int, String
 from fastcs.exceptions import FastCSException
 from fastcs.mapping import Mapping
 
@@ -62,6 +63,8 @@ class EpicsGUI:
                 return LED()
             case Int() | Float():
                 return TextRead()
+            case String():
+                return TextRead(format=TextFormat.string)
             case _:
                 raise FastCSException(f"Unsupported type {type(datatype)}: {datatype}")
 
@@ -72,6 +75,8 @@ class EpicsGUI:
                 return CheckBox()
             case Int() | Float():
                 return TextWrite()
+            case String():
+                return TextWrite(format=TextFormat.string)
             case _:
                 raise FastCSException(f"Unsupported type {type(datatype)}: {datatype}")
 

--- a/src/fastcs/backends/epics/ioc.py
+++ b/src/fastcs/backends/epics/ioc.py
@@ -7,7 +7,7 @@ from softioc.pythonSoftIoc import RecordWrapper
 
 from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.backend import Backend
-from fastcs.datatypes import Bool, DataType, Float, Int
+from fastcs.datatypes import Bool, DataType, Float, Int, String
 from fastcs.exceptions import FastCSException
 from fastcs.mapping import Mapping
 
@@ -25,6 +25,8 @@ def _get_input_record(pv_name: str, datatype: DataType) -> RecordWrapper:
             return builder.longIn(pv_name)
         case Float(prec):
             return builder.aIn(pv_name, PREC=prec)
+        case String():
+            return builder.longStringIn(pv_name)
         case _:
             raise FastCSException(f"Unsupported type {type(datatype)}: {datatype}")
 
@@ -53,6 +55,10 @@ def _get_output_record(pv_name: str, datatype: DataType, on_update: Callable) ->
         case Float(prec):
             return builder.aOut(
                 pv_name, always_update=True, on_update=on_update, PREC=prec
+            )
+        case String():
+            return builder.longStringOut(
+                pv_name, always_update=True, on_update=on_update
             )
         case _:
             raise FastCSException(f"Unsupported type {type(datatype)}: {datatype}")

--- a/src/fastcs/datatypes.py
+++ b/src/fastcs/datatypes.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Generic, TypeVar
 
-T = TypeVar("T", int, float, bool)
+T = TypeVar("T", int, float, bool, str)
 ATTRIBUTE_TYPES: tuple[type] = T.__constraints__  # type: ignore
 
 
@@ -42,3 +42,10 @@ class Bool(DataType[bool]):
     @property
     def dtype(self) -> type[bool]:
         return bool
+
+
+@dataclass(frozen=True)
+class String(DataType[str]):
+    @property
+    def dtype(self) -> type[str]:
+        return str


### PR DESCRIPTION
This adds support for a `String` `DataType`.

The EPICS backend creates `longString{In,Out}` records and `Text{Read,Write}` widgets for `String`s.

Up for discussion whether we want to use `stringin` and `stringout` records in some circumstances. My current thinking is we just use long strings for everything and then we never have to worry about character limits. I don't think there are any downsides to this.