### PR TITLE
Fix GUI PVs with no attribute path

### DIFF
--- a/src/fastcs/backends/epics/gui.py
+++ b/src/fastcs/backends/epics/gui.py
@@ -50,9 +50,8 @@ class EpicsGUI:
         self._pv_prefix = pv_prefix
 
     def _get_pv(self, attr_path: list[str], name: str):
-        attr_prefix = ":".join(attr_path)
-        pv_prefix = ":".join((self._pv_prefix, attr_prefix))
-        return f"{pv_prefix}:{name.title().replace('_', '')}"
+        attr_prefix = ":".join([self._pv_prefix] + attr_path)
+        return f"{attr_prefix}:{name.title().replace('_', '')}"
 
     @staticmethod
     def _get_read_widget(datatype: DataType) -> ReadWidget:

--- a/tests/backends/epics/test_gui.py
+++ b/tests/backends/epics/test_gui.py
@@ -1,0 +1,11 @@
+from fastcs.backends.epics.gui import EpicsGUI
+from fastcs.controller import Controller
+from fastcs.mapping import Mapping
+
+
+def test_get_pv():
+    gui = EpicsGUI(Mapping(Controller()), "DEVICE")
+
+    assert gui._get_pv([], "A") == "DEVICE:A"
+    assert gui._get_pv(["B"], "C") == "DEVICE:B:C"
+    assert gui._get_pv(["D", "E"], "F") == "DEVICE:D:E:F"


### PR DESCRIPTION
An extra `:` was inserted in the case where `attr_path` was empty.