### PR TITLE
Add structure to SubController hierarchy

### DIFF
--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -42,7 +42,14 @@ def _add_scan_method_tasks(
 
 def _create_updater_callback(attribute, controller):
     async def callback():
-        await attribute.updater.update(controller, attribute)
+        try:
+            await attribute.updater.update(controller, attribute)
+        except Exception as e:
+            print(
+                f"Update loop in {attribute.updater} stopped:\n"
+                f"{e.__class__.__name__}: {e}"
+            )
+            raise
 
     return callback
 

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -27,11 +27,11 @@ class BaseController:
     def register_sub_controller(self, name: str, sub_controller: SubController):
         if name in self.__sub_controller_tree.keys():
             raise ValueError(
-                f"Controller {self} already has a sub controller registered as {name}"
+                f"Controller {self} already has a SubController registered as {name}"
             )
         if sub_controller.path:
             raise ValueError(
-                f"Sub controller is already registered under {sub_controller.path}"
+                f"SubController is already registered under {sub_controller.path}"
             )
 
         self.__sub_controller_tree[name] = sub_controller

--- a/src/fastcs/mapping.py
+++ b/src/fastcs/mapping.py
@@ -33,7 +33,7 @@ class Mapping:
 
 def _walk_mappings(controller: BaseController) -> Iterator[SingleMapping]:
     yield _get_single_mapping(controller)
-    for sub_controller in controller.get_sub_controllers():
+    for sub_controller in controller.get_sub_controllers().values():
         yield from _walk_mappings(sub_controller)
 
 

--- a/tests/backends/epics/test_gui.py
+++ b/tests/backends/epics/test_gui.py
@@ -1,3 +1,14 @@
+from pvi.device import (
+    ButtonPanel,
+    SignalR,
+    SignalRW,
+    SignalW,
+    SignalX,
+    TextRead,
+    TextWrite,
+    ToggleButton,
+)
+
 from fastcs.backends.epics.gui import EpicsGUI
 from fastcs.controller import Controller
 from fastcs.mapping import Mapping
@@ -9,3 +20,39 @@ def test_get_pv():
     assert gui._get_pv([], "A") == "DEVICE:A"
     assert gui._get_pv(["B"], "C") == "DEVICE:B:C"
     assert gui._get_pv(["D", "E"], "F") == "DEVICE:D:E:F"
+
+
+def test_get_components(mapping):
+    gui = EpicsGUI(mapping, "DEVICE")
+
+    components = gui.extract_mapping_components(mapping.get_controller_mappings()[0])
+    assert components == [
+        SignalR(
+            name="ReadInt",
+            read_pv="DEVICE:ReadInt",
+            read_widget=TextRead(),
+        ),
+        SignalR(
+            name="ReadString",
+            read_pv="DEVICE:ReadString",
+            read_widget=TextRead(format="string"),
+        ),
+        SignalRW(
+            name="ReadWriteFloat",
+            write_pv="DEVICE:ReadWriteFloat",
+            write_widget=TextWrite(),
+            read_pv="DEVICE:ReadWriteFloat_RBV",
+            read_widget=TextRead(),
+        ),
+        SignalW(
+            name="WriteBool",
+            write_pv="DEVICE:WriteBool",
+            write_widget=ToggleButton(),
+        ),
+        SignalX(
+            name="Go",
+            write_pv="DEVICE:Go",
+            write_widget=ButtonPanel(actions={"Go": "1"}),
+            value="1",
+        ),
+    ]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,3 +1,5 @@
+import pytest
+
 from fastcs.controller import Controller, SubController
 from fastcs.mapping import _get_single_mapping, _walk_mappings
 
@@ -17,3 +19,13 @@ def test_controller_nesting():
         _get_single_mapping(sub_controller),
         _get_single_mapping(sub_sub_controller),
     ]
+
+    with pytest.raises(
+        ValueError, match=r"Controller .* already has a SubController registered as .*"
+    ):
+        controller.register_sub_controller("a", SubController())
+
+    with pytest.raises(
+        ValueError, match=r"SubController is already registered under .*"
+    ):
+        controller.register_sub_controller("c", sub_controller)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -4,12 +4,14 @@ from fastcs.mapping import _get_single_mapping, _walk_mappings
 
 def test_controller_nesting():
     controller = Controller()
-    sub_controller = SubController(["a"])
-    sub_sub_controller = SubController(["a", "b"])
+    sub_controller = SubController()
+    sub_sub_controller = SubController()
 
-    controller.register_sub_controller(sub_controller)
-    sub_controller.register_sub_controller(sub_sub_controller)
+    controller.register_sub_controller("a", sub_controller)
+    sub_controller.register_sub_controller("b", sub_sub_controller)
 
+    assert sub_controller.path == ["a"]
+    assert sub_sub_controller.path == ["a", "b"]
     assert list(_walk_mappings(controller)) == [
         _get_single_mapping(controller),
         _get_single_mapping(sub_controller),


### PR DESCRIPTION
Store sub controllers in a dictionary by path. This enables a Controller to introspect its SubControllers and their parmeters to perform higher level logic, such as fanning out configuration or creating Attributes that give a summary of underlying state (e.g. sum(), any(), all()).

Add some exception handling.