### PR TITLE
Add scheduler for scan tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
 description = "Control system agnostic framework for building Device support in Python that will work for both EPICS and Tango"
 dependencies = [
     "aioserial",
+    "apscheduler",
     "numpy",
     "pydantic",
     "pvi~=0.10.0",


### PR DESCRIPTION
Why:
- Set intervals rather than delays (avoid drift, add precision) currently the property name `period` is a bit disingenuous
- Behavior for scan tasks that take longer than their interval. Now sets to skip - Get a useful warning message: `Execution of job "readback_position (trigger: interval[0:00:00.010000], next run at: 2024-10-29 15:13:39 GMT)" skipped: maximum number of running instances reached (1)`

Possibly useful options not used:
- Dynamically add/remove tasks (Destroy tasks on exit?)
- Pause tasks (during reconnect?)
- Custom triggers (e.g. mock trigger so that we can step in testing, Cron type triggers)
- Grace period

Uncertain:
- Handle the log messages produced