### PR TITLE
Panda conversion improvements

### DIFF
--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -27,7 +27,7 @@ class Updater(Protocol):
     """Protocol for updating the cached readback value of an ``Attribute``."""
 
     # If update period is None then the attribute will not be updated as a task.
-    update_period: float | None
+    update_period: float | None = None
 
     async def update(self, controller: Any, attr: AttrR) -> None:
         pass
@@ -95,6 +95,7 @@ class AttrR(Attribute[T]):
         access_mode=AttrMode.READ,
         group: str | None = None,
         handler: Updater | None = None,
+        initial_value: T | None = None,
         allowed_values: list[T] | None = None,
         description: str | None = None,
     ) -> None:
@@ -106,7 +107,7 @@ class AttrR(Attribute[T]):
             allowed_values=allowed_values,  # type: ignore
             description=description,
         )
-        self._value: T = datatype.dtype()
+        self._value: T = datatype.dtype() if initial_value is None else initial_value
         self._update_callback: AttrCallback[T] | None = None
         self._updater = handler
 
@@ -177,7 +178,7 @@ class AttrW(Attribute[T]):
         return self._sender
 
 
-class AttrRW(AttrW[T], AttrR[T]):
+class AttrRW(AttrR[T], AttrW[T]):
     """A read-write ``Attribute``."""
 
     def __init__(
@@ -186,15 +187,17 @@ class AttrRW(AttrW[T], AttrR[T]):
         access_mode=AttrMode.READ_WRITE,
         group: str | None = None,
         handler: Handler | None = None,
+        initial_value: T | None = None,
         allowed_values: list[T] | None = None,
         description: str | None = None,
     ) -> None:
         super().__init__(
             datatype,  # type: ignore
             access_mode,
-            group,
-            handler,
-            allowed_values,  # type: ignore
+            group=group,
+            handler=handler,
+            initial_value=initial_value,
+            allowed_values=allowed_values,  # type: ignore
             description=description,
         )
 

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -52,7 +52,7 @@ class Attribute(Generic[T]):
         group: str | None = None,
         handler: Any = None,
         allowed_values: list[T] | None = None,
-        description: str | None = None
+        description: str | None = None,
     ) -> None:
         assert (
             datatype.dtype in ATTRIBUTE_TYPES
@@ -103,7 +103,7 @@ class AttrR(Attribute[T]):
             group,
             handler,
             allowed_values=allowed_values,  # type: ignore
-            description=description
+            description=description,
         )
         self._value: T = datatype.dtype()
         self._update_callback: AttrCallback[T] | None = None
@@ -136,7 +136,7 @@ class AttrW(Attribute[T]):
         group: str | None = None,
         handler: Sender | None = None,
         allowed_values: list[T] | None = None,
-        description: str | None = None
+        description: str | None = None,
     ) -> None:
         super().__init__(
             datatype,  # type: ignore
@@ -144,7 +144,7 @@ class AttrW(Attribute[T]):
             group,
             handler,
             allowed_values=allowed_values,  # type: ignore
-            description=description
+            description=description,
         )
         self._process_callback: AttrCallback[T] | None = None
         self._write_display_callback: AttrCallback[T] | None = None
@@ -186,7 +186,7 @@ class AttrRW(AttrW[T], AttrR[T]):
         group: str | None = None,
         handler: Handler | None = None,
         allowed_values: list[T] | None = None,
-        description: str | None = None
+        description: str | None = None,
     ) -> None:
         super().__init__(
             datatype,  # type: ignore
@@ -194,7 +194,7 @@ class AttrRW(AttrW[T], AttrR[T]):
             group,
             handler,
             allowed_values,  # type: ignore
-            description=description
+            description=description,
         )
 
     async def process(self, value: T) -> None:

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -52,6 +52,7 @@ class Attribute(Generic[T]):
         group: str | None = None,
         handler: Any = None,
         allowed_values: list[T] | None = None,
+        description: str | None = None
     ) -> None:
         assert (
             datatype.dtype in ATTRIBUTE_TYPES
@@ -61,6 +62,7 @@ class Attribute(Generic[T]):
         self._group = group
         self.enabled = True
         self._allowed_values: list[T] | None = allowed_values
+        self.description = description
 
     @property
     def datatype(self) -> DataType[T]:
@@ -93,6 +95,7 @@ class AttrR(Attribute[T]):
         group: str | None = None,
         handler: Updater | None = None,
         allowed_values: list[T] | None = None,
+        description: str | None = None,
     ) -> None:
         super().__init__(
             datatype,  # type: ignore
@@ -100,6 +103,7 @@ class AttrR(Attribute[T]):
             group,
             handler,
             allowed_values=allowed_values,  # type: ignore
+            description=description
         )
         self._value: T = datatype.dtype()
         self._update_callback: AttrCallback[T] | None = None
@@ -132,6 +136,7 @@ class AttrW(Attribute[T]):
         group: str | None = None,
         handler: Sender | None = None,
         allowed_values: list[T] | None = None,
+        description: str | None = None
     ) -> None:
         super().__init__(
             datatype,  # type: ignore
@@ -139,6 +144,7 @@ class AttrW(Attribute[T]):
             group,
             handler,
             allowed_values=allowed_values,  # type: ignore
+            description=description
         )
         self._process_callback: AttrCallback[T] | None = None
         self._write_display_callback: AttrCallback[T] | None = None
@@ -180,6 +186,7 @@ class AttrRW(AttrW[T], AttrR[T]):
         group: str | None = None,
         handler: Handler | None = None,
         allowed_values: list[T] | None = None,
+        description: str | None = None
     ) -> None:
         super().__init__(
             datatype,  # type: ignore
@@ -187,6 +194,7 @@ class AttrRW(AttrW[T], AttrR[T]):
             group,
             handler,
             allowed_values,  # type: ignore
+            description=description
         )
 
     async def process(self, value: T) -> None:

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Generic, Protocol, runtime_checkable
 
-from .datatypes import ATTRIBUTE_TYPES, AttrCallback, DataType, T
+from .datatypes import ATTRIBUTE_TYPES, AttrCallback, DataType, T, validate_value
 
 
 class AttrMode(Enum):
@@ -115,7 +115,7 @@ class AttrR(Attribute[T]):
         return self._value
 
     async def set(self, value: T) -> None:
-        self._value = self._datatype.dtype(value)
+        self._value = self._datatype.dtype(validate_value(self._datatype, value))
 
         if self._update_callback is not None:
             await self._update_callback(self._value)
@@ -202,6 +202,6 @@ class AttrRW(AttrR[T], AttrW[T]):
         )
 
     async def process(self, value: T) -> None:
-        await self.set(value)
+        await self.set(validate_value(self._datatype, value))
 
         await super().process(value)  # type: ignore

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -26,7 +26,8 @@ class Sender(Protocol):
 class Updater(Protocol):
     """Protocol for updating the cached readback value of an ``Attribute``."""
 
-    update_period: float
+    # If update period is None then the attribute will not be updated as a task.
+    update_period: float | None
 
     async def update(self, controller: Any, attr: AttrR) -> None:
         pass

--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -1,7 +1,6 @@
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable
-from concurrent.futures import Future
 from types import MethodType
 
 from softioc.asyncio_dispatcher import AsyncioDispatcher
@@ -21,7 +20,7 @@ class Backend:
         self._controller = controller
 
         self._initial_tasks = [controller.connect]
-        self._scan_tasks: list[Future] = []
+        self._scan_tasks: list[asyncio.Task] = []
 
         asyncio.run_coroutine_threadsafe(
             self._controller.initialise(), self._loop
@@ -41,10 +40,12 @@ class Backend:
             _link_single_controller_put_tasks(single_mapping)
             _link_attribute_sender_class(single_mapping)
 
+    def __del__(self):
+        self.stop_scan_tasks()
+
     def run(self):
         self._run_initial_tasks()
-        self._start_scan_tasks()
-
+        self.start_scan_tasks()
         self._run()
 
     def _run_initial_tasks(self):
@@ -52,19 +53,18 @@ class Backend:
             future = asyncio.run_coroutine_threadsafe(task(), self._loop)
             future.result()
 
-    def _start_scan_tasks(self):
-        async def run_tasks():
-            futures = [task() for task in _get_scan_tasks(self._mapping)]
-            for future in asyncio.as_completed(futures):
-                try:
-                    await future
-                except Exception as e:
-                    # We don't exit the ioc when a scan loop errors,
-                    # but we do print the information.
-                    print(f"Scan loop stopped with exception:\n    {e}")
-                    raise e
+    def start_scan_tasks(self):
+        self._scan_tasks = [
+            self._loop.create_task(coro()) for coro in _get_scan_coros(self._mapping)
+        ]
 
-        asyncio.run_coroutine_threadsafe(run_tasks(), self._loop)
+    def stop_scan_tasks(self):
+        for task in self._scan_tasks:
+            if not task.done():
+                try:
+                    task.cancel()
+                except asyncio.CancelledError:
+                    pass
 
     def _run(self):
         raise NotImplementedError("Specific Backend must implement _run")
@@ -106,15 +106,15 @@ def _create_sender_callback(attribute, controller):
     return callback
 
 
-def _get_scan_tasks(mapping: Mapping) -> list[Callable]:
+def _get_scan_coros(mapping: Mapping) -> list[Callable]:
     scan_dict: dict[float, list[Callable]] = defaultdict(list)
 
     for single_mapping in mapping.get_controller_mappings():
         _add_scan_method_tasks(scan_dict, single_mapping)
         _add_attribute_updater_tasks(scan_dict, single_mapping)
 
-    scan_tasks = _get_periodic_scan_tasks(scan_dict)
-    return scan_tasks
+    scan_coros = _get_periodic_scan_coros(scan_dict)
+    return scan_coros
 
 
 def _add_scan_method_tasks(
@@ -154,18 +154,18 @@ def _create_updater_callback(attribute, controller):
     return callback
 
 
-def _get_periodic_scan_tasks(scan_dict: dict[float, list[Callable]]) -> list[Callable]:
-    periodic_scan_tasks: list[Callable] = []
+def _get_periodic_scan_coros(scan_dict: dict[float, list[Callable]]) -> list[Callable]:
+    periodic_scan_coros: list[Callable] = []
     for period, methods in scan_dict.items():
-        periodic_scan_tasks.append(_create_periodic_scan_task(period, methods))
+        periodic_scan_coros.append(_create_periodic_scan_coro(period, methods))
 
-    return periodic_scan_tasks
+    return periodic_scan_coros
 
 
-def _create_periodic_scan_task(period, methods: list[Callable]) -> Callable:
-    async def scan_task() -> None:
+def _create_periodic_scan_coro(period, methods: list[Callable]) -> Callable:
+    async def scan_coro() -> None:
         while True:
             await asyncio.gather(*[method() for method in methods])
             await asyncio.sleep(period)
 
-    return scan_task
+    return scan_coro

--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -124,6 +124,8 @@ def _add_attribute_updater_tasks(
     for attribute in single_mapping.attributes.values():
         match attribute:
             case AttrR(updater=Updater(update_period=update_period)) as attribute:
+                if update_period is None:
+                    continue
                 callback = _create_updater_callback(
                     attribute, single_mapping.controller
                 )

--- a/src/fastcs/backends/epics/backend.py
+++ b/src/fastcs/backends/epics/backend.py
@@ -7,11 +7,17 @@ from .ioc import EpicsIOC, EpicsIOCOptions
 
 
 class EpicsBackend(Backend):
-    def __init__(self, controller: Controller, pv_prefix: str = "MY-DEVICE-PREFIX"):
+    def __init__(
+        self,
+        controller: Controller,
+        pv_prefix: str = "MY-DEVICE-PREFIX",
+        options: EpicsIOCOptions | None = None,
+    ):
         super().__init__(controller)
 
         self._pv_prefix = pv_prefix
-        self._ioc = EpicsIOC(pv_prefix, self._mapping)
+        options = options or EpicsIOCOptions()
+        self._ioc = EpicsIOC(pv_prefix, self._mapping, options=options)
 
     def create_docs(self, options: EpicsDocsOptions | None = None) -> None:
         EpicsDocs(self._mapping).create_docs(options)
@@ -19,5 +25,5 @@ class EpicsBackend(Backend):
     def create_gui(self, options: EpicsGUIOptions | None = None) -> None:
         EpicsGUI(self._mapping, self._pv_prefix).create_gui(options)
 
-    def _run(self, options: EpicsIOCOptions | None = None):
-        self._ioc.run(self._dispatcher, self._context, options)
+    def _run(self):
+        self._ioc.run(self._dispatcher, self._context)

--- a/src/fastcs/backends/epics/backend.py
+++ b/src/fastcs/backends/epics/backend.py
@@ -11,19 +11,22 @@ class EpicsBackend(Backend):
         self,
         controller: Controller,
         pv_prefix: str = "MY-DEVICE-PREFIX",
-        options: EpicsIOCOptions | None = None,
+        ioc_options: EpicsIOCOptions | None = None,
     ):
         super().__init__(controller)
 
         self._pv_prefix = pv_prefix
-        options = options or EpicsIOCOptions()
-        self._ioc = EpicsIOC(pv_prefix, self._mapping, options=options)
+        self.ioc_options = ioc_options or EpicsIOCOptions()
+        self._ioc = EpicsIOC(pv_prefix, self._mapping, options=ioc_options)
 
-    def create_docs(self, options: EpicsDocsOptions | None = None) -> None:
-        EpicsDocs(self._mapping).create_docs(options)
+    def create_docs(self, docs_options: EpicsDocsOptions | None = None) -> None:
+        EpicsDocs(self._mapping).create_docs(docs_options)
 
-    def create_gui(self, options: EpicsGUIOptions | None = None) -> None:
-        EpicsGUI(self._mapping, self._pv_prefix).create_gui(options)
+    def create_gui(self, gui_options: EpicsGUIOptions | None = None) -> None:
+        assert self.ioc_options.name_options is not None
+        EpicsGUI(
+            self._mapping, self._pv_prefix, self.ioc_options.name_options
+        ).create_gui(gui_options)
 
     def _run(self):
         self._ioc.run(self._dispatcher, self._context)

--- a/src/fastcs/backends/epics/gui.py
+++ b/src/fastcs/backends/epics/gui.py
@@ -27,7 +27,10 @@ from pvi.device import (
 from pydantic import ValidationError
 
 from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW
-from fastcs.backends.epics.util import EpicsNameOptions, _convert_attribute_name_to_pv_name
+from fastcs.backends.epics.util import (
+    EpicsNameOptions,
+    _convert_attribute_name_to_pv_name,
+)
 from fastcs.cs_methods import Command
 from fastcs.datatypes import Bool, Float, Int, String
 from fastcs.exceptions import FastCSException
@@ -65,13 +68,17 @@ class EpicsGUI:
             ]
             + [
                 _convert_attribute_name_to_pv_name(
-                    attr_name, self.epics_name_options.pv_naming_convention, is_attribute=False
+                    attr_name,
+                    self.epics_name_options.pv_naming_convention,
+                    is_attribute=False,
                 )
                 for attr_name in attr_path
             ]
             + [
                 _convert_attribute_name_to_pv_name(
-                    name, self.epics_name_options.pv_naming_convention, is_attribute=True
+                    name,
+                    self.epics_name_options.pv_naming_convention,
+                    is_attribute=True,
                 ),
             ],
         )

--- a/src/fastcs/backends/epics/gui.py
+++ b/src/fastcs/backends/epics/gui.py
@@ -27,7 +27,7 @@ from pvi.device import (
 from pydantic import ValidationError
 
 from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW
-from fastcs.backends.epics.util import EpicsNameOptions, _convert_attr_name_to_pv_name
+from fastcs.backends.epics.util import EpicsNameOptions, _convert_attribute_name_to_pv_name
 from fastcs.cs_methods import Command
 from fastcs.datatypes import Bool, Float, Int, String
 from fastcs.exceptions import FastCSException
@@ -64,14 +64,14 @@ class EpicsGUI:
                 self._pv_prefix,
             ]
             + [
-                _convert_attr_name_to_pv_name(
-                    attr_name, self.epics_name_options.pv_naming_convention
+                _convert_attribute_name_to_pv_name(
+                    attr_name, self.epics_name_options.pv_naming_convention, is_attribute=False
                 )
                 for attr_name in attr_path
             ]
             + [
-                _convert_attr_name_to_pv_name(
-                    name, self.epics_name_options.pv_naming_convention
+                _convert_attribute_name_to_pv_name(
+                    name, self.epics_name_options.pv_naming_convention, is_attribute=True
                 ),
             ],
         )

--- a/src/fastcs/backends/epics/ioc.py
+++ b/src/fastcs/backends/epics/ioc.py
@@ -350,7 +350,7 @@ def _get_output_record(pv: str, attribute: AttrW, on_update: Callable) -> Any:
         attribute_fields.update({"DESC": attribute.description})
     if attr_is_enum(attribute):
         assert attribute.allowed_values is not None and all(
-            isinstance(v, str) for v in attribute.allowed_values
+            isinstance(v, str) or isinstance(v, int) for v in attribute.allowed_values
         )
         state_keys = dict(zip(MBB_STATE_FIELDS, attribute.allowed_values, strict=False))
         return builder.mbbOut(

--- a/src/fastcs/backends/epics/ioc.py
+++ b/src/fastcs/backends/epics/ioc.py
@@ -330,11 +330,26 @@ def _get_input_record(pv: str, attribute: AttrR) -> RecordWrapper:
     match attribute.datatype:
         case Bool(znam, onam):
             return builder.boolIn(pv, ZNAM=znam, ONAM=onam, **attribute_fields)
-        case Int():
-            return builder.longIn(pv, EGU=attribute.datatype.units, **attribute_fields)
-        case Float(prec):
+        case Int(units, min, max, min_alarm, max_alarm):
+            return builder.longIn(
+                pv,
+                EGU=units,
+                DRVL=min,
+                DRVH=max,
+                LOPR=min_alarm,
+                HOPR=max_alarm,
+                **attribute_fields,
+            )
+        case Float(prec, units, min, max, min_alarm, max_alarm):
             return builder.aIn(
-                pv, EGU=attribute.datatype.units, PREC=prec, **attribute_fields
+                pv,
+                PREC=prec,
+                EGU=units,
+                DRVL=min,
+                DRVH=max,
+                LOPR=min_alarm,
+                HOPR=max_alarm,
+                **attribute_fields,
             )
         case String():
             return builder.longStringIn(pv, **attribute_fields)
@@ -370,21 +385,29 @@ def _get_output_record(pv: str, attribute: AttrW, on_update: Callable) -> Any:
                 always_update=True,
                 on_update=on_update,
             )
-        case Int(units=units):
+        case Int(units, min, max, min_alarm, max_alarm):
             return builder.longOut(
                 pv,
                 always_update=True,
                 on_update=on_update,
                 EGU=units,
+                DRVL=min,
+                DRVH=max,
+                LOPR=min_alarm,
+                HOPR=max_alarm,
                 **attribute_fields,
             )
-        case Float(prec=prec, units=units):
+        case Float(prec, units, min, max, min_alarm, max_alarm):
             return builder.aOut(
                 pv,
                 always_update=True,
                 on_update=on_update,
-                EGU=units,
                 PREC=prec,
+                EGU=units,
+                DRVL=min,
+                DRVH=max,
+                LOPR=min_alarm,
+                HOPR=max_alarm,
                 **attribute_fields,
             )
         case String():

--- a/src/fastcs/backends/epics/ioc.py
+++ b/src/fastcs/backends/epics/ioc.py
@@ -30,7 +30,6 @@ class EpicsIOCOptions:
     name_options: EpicsNameOptions = EpicsNameOptions()
 
 
-
 class EpicsIOC:
     def __init__(
         self, pv_prefix: str, mapping: Mapping, options: EpicsIOCOptions | None = None
@@ -74,7 +73,7 @@ class EpicsIOC:
                     _convert_attribute_name_to_pv_name(
                         path,
                         self._name_options.pv_naming_convention,
-                        is_attribute=False
+                        is_attribute=False,
                     )
                     for path in child.path
                 ]
@@ -96,7 +95,9 @@ class EpicsIOC:
             ]
             for attr_name, attribute in single_mapping.attributes.items():
                 pv_name = _convert_attribute_name_to_pv_name(
-                    attr_name, self._name_options.pv_naming_convention, is_attribute=True
+                    attr_name,
+                    self._name_options.pv_naming_convention,
+                    is_attribute=True,
                 )
                 _pv_prefix = self._name_options.pv_separator.join(
                     [pv_prefix] + formatted_path
@@ -169,7 +170,9 @@ class EpicsIOC:
             ]
             for attr_name, method in single_mapping.command_methods.items():
                 pv_name = _convert_attribute_name_to_pv_name(
-                    attr_name, self._name_options.pv_naming_convention, is_attribute=True
+                    attr_name,
+                    self._name_options.pv_naming_convention,
+                    is_attribute=True,
                 )
                 _pv_prefix = self._name_options.pv_separator.join(
                     [pv_prefix] + formatted_path

--- a/src/fastcs/backends/epics/ioc.py
+++ b/src/fastcs/backends/epics/ioc.py
@@ -24,15 +24,29 @@ EPICS_MAX_NAME_LENGTH = 60
 
 
 class PvNamingConvention(Enum):
-    NO_CONVERSION = 0
-    PASCAL = 1
-    CAPITALIZED = 2
+    NO_CONVERSION = "NO_CONVERSION"
+    PASCAL = "PASCAL"
+    CAPITALIZED = "CAPITALIZED"
+
+
+DEFAULT_PV_SEPARATOR = ":"
 
 
 @dataclass
 class EpicsIOCOptions:
     terminal: bool = True
     pv_naming_convention: PvNamingConvention = PvNamingConvention.PASCAL
+    pv_separator: str = DEFAULT_PV_SEPARATOR
+
+
+def _convert_attr_name_to_pv_name(
+    attr_name: str, naming_convention: PvNamingConvention
+) -> str:
+    if naming_convention == PvNamingConvention.PASCAL:
+        return attr_name.title().replace("_", "")
+    elif naming_convention == PvNamingConvention.CAPITALIZED:
+        return attr_name.upper().replace("_", "-")
+    return attr_name
 
 
 class EpicsIOC:
@@ -40,13 +54,11 @@ class EpicsIOC:
         self, pv_prefix: str, mapping: Mapping, options: EpicsIOCOptions | None = None
     ):
         self.options = options or EpicsIOCOptions()
-        _add_pvi_info(f"{pv_prefix}:PVI")
-        _add_sub_controller_pvi_info(pv_prefix, mapping.controller)
+        _add_pvi_info(f"{pv_prefix}{self.options.pv_separator}PVI")
+        self._add_sub_controller_pvi_info(pv_prefix, mapping.controller)
 
-        _create_and_link_attribute_pvs(pv_prefix, mapping)
-        _create_and_link_command_pvs(
-            pv_prefix, mapping, self.options.pv_naming_convention
-        )
+        self._create_and_link_attribute_pvs(pv_prefix, mapping)
+        self._create_and_link_command_pvs(pv_prefix, mapping)
 
     def run(
         self,
@@ -58,6 +70,209 @@ class EpicsIOC:
 
         if self.options.terminal:
             softioc.interactive_ioc(context)
+
+    def _add_sub_controller_pvi_info(self, pv_prefix: str, parent: BaseController):
+        """Add PVI references from controller to its sub controllers, recursively.
+
+        Args:
+            pv_prefix: PV Prefix of IOC
+            parent: Controller to add PVI refs for
+
+        """
+        parent_pvi = self.options.pv_separator.join([pv_prefix] + parent.path + ["PVI"])
+
+        for child in parent.get_sub_controllers().values():
+            child_pvi = self.options.pv_separator.join(
+                [pv_prefix]
+                + [
+                    _convert_attr_name_to_pv_name(
+                        path, self.options.pv_naming_convention
+                    )
+                    for path in child.path
+                ]
+                + ["PVI"]
+            )
+            child_name = child.path[-1].lower()
+
+            _add_pvi_info(child_pvi, parent_pvi, child_name)
+
+            self._add_sub_controller_pvi_info(pv_prefix, child)
+
+    def _create_and_link_attribute_pvs(self, pv_prefix: str, mapping: Mapping) -> None:
+        for single_mapping in mapping.get_controller_mappings():
+            formatted_path = [
+                _convert_attr_name_to_pv_name(p, self.options.pv_naming_convention)
+                for p in single_mapping.controller.path
+            ]
+            for attr_name, attribute in single_mapping.attributes.items():
+                pv_name = _convert_attr_name_to_pv_name(
+                    attr_name, self.options.pv_naming_convention
+                )
+                _pv_prefix = self.options.pv_separator.join(
+                    [pv_prefix] + formatted_path
+                )
+                full_pv_name_length = len(
+                    f"{_pv_prefix}{self.options.pv_separator}{pv_name}"
+                )
+
+                if full_pv_name_length > EPICS_MAX_NAME_LENGTH:
+                    attribute.enabled = False
+                    print(
+                        f"Not creating PV for {attr_name} for controller"
+                        f" {single_mapping.controller.path} as full name would exceed"
+                        f" {EPICS_MAX_NAME_LENGTH} characters"
+                    )
+                    continue
+
+                match attribute:
+                    case AttrRW():
+                        if full_pv_name_length > (EPICS_MAX_NAME_LENGTH - 4):
+                            print(
+                                f"Not creating PVs for {attr_name} as _RBV PV"
+                                f" name would exceed {EPICS_MAX_NAME_LENGTH}"
+                                " characters"
+                            )
+                            attribute.enabled = False
+                        else:
+                            self._create_and_link_read_pv(
+                                _pv_prefix, f"{pv_name}_RBV", attr_name, attribute
+                            )
+                            self._create_and_link_write_pv(
+                                _pv_prefix, pv_name, attr_name, attribute
+                            )
+                    case AttrR():
+                        self._create_and_link_read_pv(
+                            _pv_prefix, pv_name, attr_name, attribute
+                        )
+                    case AttrW():
+                        self._create_and_link_write_pv(
+                            _pv_prefix, pv_name, attr_name, attribute
+                        )
+
+    def _create_and_link_read_pv(
+        self, pv_prefix: str, pv_name: str, attr_name: str, attribute: AttrR[T]
+    ) -> None:
+        if attr_is_enum(attribute):
+
+            async def async_record_set(value: T):
+                record.set(enum_value_to_index(attribute, value))
+
+        else:
+
+            async def async_record_set(value: T):
+                record.set(value)
+
+        record = _get_input_record(
+            f"{pv_prefix}{self.options.pv_separator}{pv_name}", attribute
+        )
+        self._add_attr_pvi_info(record, pv_prefix, attr_name, "r")
+
+        attribute.set_update_callback(async_record_set)
+
+    def _create_and_link_command_pvs(self, pv_prefix: str, mapping: Mapping) -> None:
+        for single_mapping in mapping.get_controller_mappings():
+            formatted_path = [
+                _convert_attr_name_to_pv_name(p, self.options.pv_naming_convention)
+                for p in single_mapping.controller.path
+            ]
+            for attr_name, method in single_mapping.command_methods.items():
+                pv_name = _convert_attr_name_to_pv_name(
+                    attr_name, self.options.pv_naming_convention
+                )
+                _pv_prefix = self.options.pv_separator.join(
+                    [pv_prefix] + formatted_path
+                )
+                if (
+                    len(f"{_pv_prefix}{self.options.pv_separator}{pv_name}")
+                    > EPICS_MAX_NAME_LENGTH
+                ):
+                    print(
+                        f"Not creating PV for {attr_name} as full name would exceed"
+                        f" {EPICS_MAX_NAME_LENGTH} characters"
+                    )
+                    method.enabled = False
+                else:
+                    self._create_and_link_command_pv(
+                        _pv_prefix,
+                        pv_name,
+                        attr_name,
+                        MethodType(method.fn, single_mapping.controller),
+                    )
+
+    def _create_and_link_write_pv(
+        self, pv_prefix: str, pv_name: str, attr_name: str, attribute: AttrW[T]
+    ) -> None:
+        if attr_is_enum(attribute):
+
+            async def on_update(value):
+                await attribute.process_without_display_update(
+                    enum_index_to_value(attribute, value)
+                )
+
+            async def async_write_display(value: T):
+                record.set(enum_value_to_index(attribute, value), process=False)
+
+        else:
+
+            async def on_update(value):
+                await attribute.process_without_display_update(value)
+
+            async def async_write_display(value: T):
+                record.set(value, process=False)
+
+        record = _get_output_record(
+            f"{pv_prefix}{self.options.pv_separator}{pv_name}",
+            attribute,
+            on_update=on_update,
+        )
+
+        self._add_attr_pvi_info(record, pv_prefix, attr_name, "w")
+
+        attribute.set_write_display_callback(async_write_display)
+
+    def _create_and_link_command_pv(
+        self, pv_prefix: str, pv_name: str, attr_name: str, method: Callable
+    ) -> None:
+        async def wrapped_method(_: Any):
+            await method()
+
+        record = builder.aOut(
+            f"{pv_prefix}{self.options.pv_separator}{pv_name}",
+            initial_value=0,
+            always_update=True,
+            on_update=wrapped_method,
+        )
+
+        self._add_attr_pvi_info(record, pv_prefix, attr_name, "x")
+
+    def _add_attr_pvi_info(
+        self,
+        record: RecordWrapper,
+        prefix: str,
+        name: str,
+        access_mode: Literal["r", "w", "rw", "x"],
+    ):
+        """Add an info tag to a record to include it in the PVI for the controller.
+
+        Args:
+            record: Record to add info tag to
+            prefix: PV prefix of controller
+            name: Name of parameter to add to PVI
+            access_mode: Access mode of parameter
+
+        """
+        record.add_info(
+            "Q:group",
+            {
+                f"{prefix}{self.options.pv_separator}PVI": {
+                    f"value.{name}.{access_mode}": {
+                        "+channel": "NAME",
+                        "+type": "plain",
+                        "+trigger": f"value.{name}.{access_mode}",
+                    }
+                }
+            },
+        )
 
 
 def _add_pvi_info(
@@ -105,82 +320,6 @@ def _add_pvi_info(
     record.add_info("Q:group", q_group)
 
 
-def _add_sub_controller_pvi_info(pv_prefix: str, parent: BaseController):
-    """Add PVI references from controller to its sub controllers, recursively.
-
-    Args:
-        pv_prefix: PV Prefix of IOC
-        parent: Controller to add PVI refs for
-
-    """
-    parent_pvi = ":".join([pv_prefix] + parent.path + ["PVI"])
-
-    for child in parent.get_sub_controllers().values():
-        child_pvi = ":".join([pv_prefix] + child.path + ["PVI"])
-        child_name = child.path[-1].lower()
-
-        _add_pvi_info(child_pvi, parent_pvi, child_name)
-
-        _add_sub_controller_pvi_info(pv_prefix, child)
-
-
-def _create_and_link_attribute_pvs(pv_prefix: str, mapping: Mapping) -> None:
-    for single_mapping in mapping.get_controller_mappings():
-        path = single_mapping.controller.path
-        for attr_name, attribute in single_mapping.attributes.items():
-            pv_name = attr_name.replace("_", "")
-            _pv_prefix = ":".join([pv_prefix] + path)
-            full_pv_name_length = len(f"{_pv_prefix}:{pv_name}")
-
-            if full_pv_name_length > EPICS_MAX_NAME_LENGTH:
-                attribute.enabled = False
-                print(
-                    f"Not creating PV for {attr_name} for controller"
-                    f" {single_mapping.controller.path} as full name would exceed"
-                    f" {EPICS_MAX_NAME_LENGTH} characters"
-                )
-                continue
-
-            match attribute:
-                case AttrRW():
-                    if full_pv_name_length > (EPICS_MAX_NAME_LENGTH - 4):
-                        print(
-                            f"Not creating PVs for {attr_name} as _RBV PV"
-                            f" name would exceed {EPICS_MAX_NAME_LENGTH}"
-                            " characters"
-                        )
-                        attribute.enabled = False
-                    else:
-                        _create_and_link_read_pv(
-                            _pv_prefix, f"{pv_name}_RBV", attr_name, attribute
-                        )
-                        _create_and_link_write_pv(
-                            _pv_prefix, pv_name, attr_name, attribute
-                        )
-                case AttrR():
-                    _create_and_link_read_pv(_pv_prefix, pv_name, attr_name, attribute)
-                case AttrW():
-                    _create_and_link_write_pv(_pv_prefix, pv_name, attr_name, attribute)
-
-
-def _create_and_link_read_pv(
-    pv_prefix: str, pv_name: str, attr_name: str, attribute: AttrR[T]
-) -> None:
-    if attr_is_enum(attribute):
-
-        async def async_record_set(value: T):
-            record.set(enum_value_to_index(attribute, value))
-    else:
-
-        async def async_record_set(value: T):
-            record.set(value)
-
-    record = _get_input_record(f"{pv_prefix}:{pv_name}", attribute)
-    _add_attr_pvi_info(record, pv_prefix, attr_name, "r")
-
-    attribute.set_update_callback(async_record_set)
-
-
 def _get_input_record(pv: str, attribute: AttrR) -> RecordWrapper:
     attribute_fields = {}
     if attribute.description is not None:
@@ -206,36 +345,6 @@ def _get_input_record(pv: str, attribute: AttrR) -> RecordWrapper:
             raise FastCSException(
                 f"Unsupported type {type(attribute.datatype)}: {attribute.datatype}"
             )
-
-
-def _create_and_link_write_pv(
-    pv_prefix: str, pv_name: str, attr_name: str, attribute: AttrW[T]
-) -> None:
-    if attr_is_enum(attribute):
-
-        async def on_update(value):
-            await attribute.process_without_display_update(
-                enum_index_to_value(attribute, value)
-            )
-
-        async def async_write_display(value: T):
-            record.set(enum_value_to_index(attribute, value), process=False)
-
-    else:
-
-        async def on_update(value):
-            await attribute.process_without_display_update(value)
-
-        async def async_write_display(value: T):
-            record.set(value, process=False)
-
-    record = _get_output_record(
-        f"{pv_prefix}:{pv_name}", attribute, on_update=on_update
-    )
-
-    _add_attr_pvi_info(record, pv_prefix, attr_name, "w")
-
-    attribute.set_write_display_callback(async_write_display)
 
 
 def _get_output_record(pv: str, attribute: AttrW, on_update: Callable) -> Any:
@@ -284,81 +393,3 @@ def _get_output_record(pv: str, attribute: AttrW, on_update: Callable) -> Any:
             raise FastCSException(
                 f"Unsupported type {type(attribute.datatype)}: {attribute.datatype}"
             )
-
-
-def _convert_attr_name_to_pv_name(
-    attr_name: str, naming_convention: PvNamingConvention
-) -> str:
-    if naming_convention == PvNamingConvention.PASCAL:
-        return attr_name.title().replace("_", "")
-    elif naming_convention == PvNamingConvention.CAPITALIZED:
-        return attr_name.upper().replace("_", "-")
-    return attr_name
-
-
-def _create_and_link_command_pvs(
-    pv_prefix: str, mapping: Mapping, naming_convention: PvNamingConvention
-) -> None:
-    for single_mapping in mapping.get_controller_mappings():
-        path = single_mapping.controller.path
-        for attr_name, method in single_mapping.command_methods.items():
-            pv_name = _convert_attr_name_to_pv_name(attr_name, naming_convention)
-            _pv_prefix = ":".join([pv_prefix] + path)
-            if len(f"{_pv_prefix}:{pv_name}") > EPICS_MAX_NAME_LENGTH:
-                print(
-                    f"Not creating PV for {attr_name} as full name would exceed"
-                    f" {EPICS_MAX_NAME_LENGTH} characters"
-                )
-                method.enabled = False
-            else:
-                _create_and_link_command_pv(
-                    _pv_prefix,
-                    pv_name,
-                    attr_name,
-                    MethodType(method.fn, single_mapping.controller),
-                )
-
-
-def _create_and_link_command_pv(
-    pv_prefix: str, pv_name: str, attr_name: str, method: Callable
-) -> None:
-    async def wrapped_method(_: Any):
-        await method()
-
-    record = builder.aOut(
-        f"{pv_prefix}:{pv_name}",
-        initial_value=0,
-        always_update=True,
-        on_update=wrapped_method,
-    )
-
-    _add_attr_pvi_info(record, pv_prefix, attr_name, "x")
-
-
-def _add_attr_pvi_info(
-    record: RecordWrapper,
-    prefix: str,
-    name: str,
-    access_mode: Literal["r", "w", "rw", "x"],
-):
-    """Add an info tag to a record to include it in the PVI for the controller.
-
-    Args:
-        record: Record to add info tag to
-        prefix: PV prefix of controller
-        name: Name of parameter to add to PVI
-        access_mode: Access mode of parameter
-
-    """
-    record.add_info(
-        "Q:group",
-        {
-            f"{prefix}:PVI": {
-                f"value.{name}.{access_mode}": {
-                    "+channel": "NAME",
-                    "+type": "plain",
-                    "+trigger": f"value.{name}.{access_mode}",
-                }
-            }
-        },
-    )

--- a/src/fastcs/backends/epics/ioc.py
+++ b/src/fastcs/backends/epics/ioc.py
@@ -331,9 +331,11 @@ def _get_input_record(pv: str, attribute: AttrR) -> RecordWrapper:
         case Bool(znam, onam):
             return builder.boolIn(pv, ZNAM=znam, ONAM=onam, **attribute_fields)
         case Int():
-            return builder.longIn(pv, **attribute_fields)
+            return builder.longIn(pv, EGU=attribute.datatype.units, **attribute_fields)
         case Float(prec):
-            return builder.aIn(pv, PREC=prec, **attribute_fields)
+            return builder.aIn(
+                pv, EGU=attribute.datatype.units, PREC=prec, **attribute_fields
+            )
         case String():
             return builder.longStringIn(pv, **attribute_fields)
         case _:
@@ -368,15 +370,20 @@ def _get_output_record(pv: str, attribute: AttrW, on_update: Callable) -> Any:
                 always_update=True,
                 on_update=on_update,
             )
-        case Int():
+        case Int(units=units):
             return builder.longOut(
-                pv, always_update=True, on_update=on_update, **attribute_fields
+                pv,
+                always_update=True,
+                on_update=on_update,
+                EGU=units,
+                **attribute_fields,
             )
-        case Float(prec):
+        case Float(prec=prec, units=units):
             return builder.aOut(
                 pv,
                 always_update=True,
                 on_update=on_update,
+                EGU=units,
                 PREC=prec,
                 **attribute_fields,
             )

--- a/src/fastcs/backends/epics/ioc.py
+++ b/src/fastcs/backends/epics/ioc.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from types import MethodType
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import numpy as np
 from softioc import builder, fields, softioc
@@ -18,8 +18,9 @@ from fastcs.backends.epics.util import (
     enum_index_to_value,
     enum_value_to_index,
 )
+from epicsdbbuilder import RecordName
 from fastcs.controller import BaseController
-from fastcs.datatypes import Bool, DataType, Float, Int, String, T
+from fastcs.datatypes import Bool, DataType, Float, Int, String, T, Table, WaveForm
 from fastcs.exceptions import FastCSException
 from fastcs.mapping import Mapping
 
@@ -41,6 +42,7 @@ DATATYPE_NAME_TO_RECORD_FIELD = {
     "max_alarm": "HOPR",
     "znam": "ZNAM",
     "onam": "ONAM",
+    "length": "length",
 }
 
 
@@ -300,6 +302,114 @@ class EpicsIOC:
             },
         )
 
+    def create_table(self, top_level_pv: str, datatype: np.dtype):
+        pva_table_name = RecordName(top_level_pv)
+
+        columns = datatype.descr
+        if not columns or not all(
+            isinstance(column, tuple) and len(column) == 2 for column in columns
+        ):
+            raise FastCSException("Table datatype must have a structured dtype.")
+
+        columns = cast(list[tuple[str, np.dtype]], columns)
+
+        labels_record: RecordWrapper = builder.WaveformOut(
+            top_level_pv + ":LABELS",
+            initial_value=np.array([name.encode() for (name, _) in columns]),
+        )
+
+        labels_record.add_info(
+            "Q:group",
+            {
+                pva_table_name: {
+                    "+id": "epics:nt/NTTable:1.0",
+                    "labels": {"+type": "plain", "+channel": "VAL"},
+                }
+            },
+        )
+
+        pv_rec = builder.longStringIn(
+            top_level_pv + ":PV",
+            initial_value=pva_table_name,
+        )
+        block, field = top_level_pv.rsplit(":", maxsplit=1)
+        _add_pvi_info(field, block, field.lower())
+
+        self.table_fields_records = OrderedDict(
+            {
+                k: TableFieldRecordContainer(v, None)
+                for k, v in field_info.fields.items()
+            }
+        )
+        self.all_values_dict = all_values_dict
+
+        pvi_table_name = epics_to_pvi_name(table_name)
+
+        # The PVI group to put all records into
+        pvi_group = PviGroup.PARAMETERS
+        Pvi.add_pvi_info(
+            table_name,
+            pvi_group,
+            SignalRW(
+                name=pvi_table_name,
+                write_pv=f"{Pvi.record_prefix}:{table_name}",
+                write_widget=TableWrite(widgets=[]),
+            ),
+        )
+
+        # Note that the table_updater's table_fields are guaranteed sorted in bit order,
+        # unlike field_info's fields. This means the record dict inside the table
+        # updater are also in the same bit order.
+        value = all_values_dict[table_name]
+        assert isinstance(value, list)
+        field_data = words_to_table(value, field_info)
+
+        for i, (field_name, field_record_container) in enumerate(
+            self.table_fields_records.items()
+        ):
+            field_details = field_record_container.field
+
+            full_name = table_name + ":" + field_name
+            full_name = EpicsName(full_name)
+            description = trim_description(field_details.description, full_name)
+
+            waveform_val = self._construct_waveform_val(
+                field_data, field_name, field_details
+            )
+
+            field_record: RecordWrapper = builder.WaveformOut(
+                full_name,
+                DESC=description,
+                validate=self.validate_waveform,
+                initial_value=waveform_val,
+                length=field_info.max_length,
+            )
+
+            field_pva_info = {
+                "+type": "plain",
+                "+channel": "VAL",
+                "+putorder": i + 1,
+                "+trigger": "",
+            }
+
+            pva_info = {f"value.{field_name.lower()}": field_pva_info}
+
+            # For the last column in the table
+            if i == len(self.table_fields_records) - 1:
+                # Trigger a monitor update
+                field_pva_info["+trigger"] = "*"
+                # Add metadata
+                pva_info[""] = {"+type": "meta", "+channel": "VAL"}
+
+            field_record.add_info(
+                "Q:group",
+                {pva_table_name: pva_info},
+            )
+
+            field_record_container.record_info = RecordInfo(lambda x: x, None, False)
+
+            field_record_container.record_info.add_record(field_record)
+
 
 def _add_pvi_info(
     pvi: str,
@@ -384,6 +494,12 @@ def _get_input_record(pv: str, attribute: AttrR) -> RecordWrapper:
             return builder.longStringIn(
                 pv, **datatype_to_epics_fields(attribute.datatype), **attribute_fields
             )
+        case WaveForm():
+            return builder.WaveformIn(
+                pv, **datatype_to_epics_fields(attribute.datatype), **attribute_fields
+            )
+        case Table(numpy_datatype):
+            return create_table(pv, numpy_datatype)
         case _:
             raise FastCSException(
                 f"Unsupported type {type(attribute.datatype)}: {attribute.datatype}"
@@ -438,7 +554,15 @@ def _get_output_record(pv: str, attribute: AttrW, on_update: Callable) -> Any:
             )
         case String():
             return builder.longStringOut(
-                pv, always_update=True, on_update=on_update, **attribute_fields
+                pv,
+                always_update=True,
+                on_update=on_update,
+                **datatype_to_epics_fields(attribute.datatype),
+                **attribute_fields,
+            )
+        case WaveForm():
+            return builder.WaveformOut(
+                pv, **datatype_to_epics_fields(attribute.datatype), **attribute_fields
             )
         case _:
             raise FastCSException(

--- a/src/fastcs/backends/epics/util.py
+++ b/src/fastcs/backends/epics/util.py
@@ -51,10 +51,16 @@ def _convert_attribute_name_to_pv_name(
         return attr_name.title().replace("_", "")
     elif naming_convention == PvNamingConvention.CAPITALIZED:
         return attr_name.upper().replace("_", "-")
-    elif naming_convention == PvNamingConvention.CAPITALIZED_CONTROLLER_PASCAL_ATTRIBUTE:
+    elif (
+        naming_convention == PvNamingConvention.CAPITALIZED_CONTROLLER_PASCAL_ATTRIBUTE
+    ):
         if is_attribute:
-            return _convert_attribute_name_to_pv_name(attr_name, PvNamingConvention.PASCAL, is_attribute)
-        return _convert_attribute_name_to_pv_name(attr_name, PvNamingConvention.CAPITALIZED)
+            return _convert_attribute_name_to_pv_name(
+                attr_name, PvNamingConvention.PASCAL, is_attribute
+            )
+        return _convert_attribute_name_to_pv_name(
+            attr_name, PvNamingConvention.CAPITALIZED
+        )
     return attr_name
 
 

--- a/src/fastcs/backends/epics/util.py
+++ b/src/fastcs/backends/epics/util.py
@@ -32,6 +32,7 @@ class PvNamingConvention(Enum):
     NO_CONVERSION = "NO_CONVERSION"
     PASCAL = "PASCAL"
     CAPITALIZED = "CAPITALIZED"
+    CAPITALIZED_CONTROLLER_PASCAL_ATTRIBUTE = "CAPITALIZED_CONTROLLER_PASCAL_ATTRIBUTE"
 
 
 DEFAULT_PV_SEPARATOR = ":"
@@ -43,13 +44,17 @@ class EpicsNameOptions:
     pv_separator: str = DEFAULT_PV_SEPARATOR
 
 
-def _convert_attr_name_to_pv_name(
-    attr_name: str, naming_convention: PvNamingConvention
+def _convert_attribute_name_to_pv_name(
+    attr_name: str, naming_convention: PvNamingConvention, is_attribute: bool = False
 ) -> str:
     if naming_convention == PvNamingConvention.PASCAL:
         return attr_name.title().replace("_", "")
     elif naming_convention == PvNamingConvention.CAPITALIZED:
         return attr_name.upper().replace("_", "-")
+    elif naming_convention == PvNamingConvention.CAPITALIZED_CONTROLLER_PASCAL_ATTRIBUTE:
+        if is_attribute:
+            return _convert_attribute_name_to_pv_name(attr_name, PvNamingConvention.PASCAL, is_attribute)
+        return _convert_attribute_name_to_pv_name(attr_name, PvNamingConvention.CAPITALIZED)
     return attr_name
 
 

--- a/src/fastcs/backends/tango/dsr.py
+++ b/src/fastcs/backends/tango/dsr.py
@@ -35,7 +35,7 @@ def _wrap_updater_fget(
 
 
 def _tango_polling_period(attribute: AttrR) -> int:
-    if attribute.updater is not None:
+    if attribute.updater is not None and attribute.updater.update_period is not None:
         # Convert to integer milliseconds
         return int(attribute.updater.update_period * 1000)
 

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -6,17 +6,22 @@ from .attributes import Attribute
 
 
 class BaseController:
-    def __init__(self, path: list[str] | None = None) -> None:
+    def __init__(
+        self, path: list[str] | None = None, search_device_for_attributes: bool = True
+    ) -> None:
         self._path: list[str] = path or []
-        self.__sub_controller_tree: dict[str, BaseController] = {}
+        # If this is set to `False`, FastCS will only use attributes defined in
+        # `additional_attributes`.
+        self.search_device_for_attributes = search_device_for_attributes
 
+        self.__sub_controller_tree: dict[str, BaseController] = {}
         self._bind_attrs()
 
     @property
-    def additional_attributes(self) -> dict[str, Attribute] | None:
-        """FastCS will look for attributes on the controller, but additional attribtues
-        be provided here."""
-        return None
+    def additional_attributes(self) -> dict[str, Attribute]:
+        """FastCS will look for attributes on the controller, but additional attributes
+        are provided by this method."""
+        return {}
 
     @property
     def path(self) -> list[str]:
@@ -58,8 +63,8 @@ class Controller(BaseController):
     generating a UI or creating parameters for a control system.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, search_device_for_attributes: bool = True) -> None:
+        super().__init__(search_device_for_attributes=search_device_for_attributes)
 
     async def initialise(self) -> None:
         pass
@@ -75,5 +80,5 @@ class SubController(BaseController):
     it as part of a larger device.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, search_device_for_attributes: bool = True) -> None:
+        super().__init__(search_device_for_attributes=search_device_for_attributes)

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -13,6 +13,12 @@ class BaseController:
         self._bind_attrs()
 
     @property
+    def additional_attributes(self) -> dict[str, Attribute] | None:
+        """FastCS will look for attributes on the controller, but additional attribtues
+        be provided here."""
+        return None
+
+    @property
     def path(self) -> list[str]:
         """Path prefix of attributes, recursively including parent ``Controller``s."""
         return self._path

--- a/src/fastcs/datatypes.py
+++ b/src/fastcs/datatypes.py
@@ -25,6 +25,8 @@ class DataType(Generic[T]):
 class Int(DataType[int]):
     """`DataType` mapping to builtin ``int``."""
 
+    units: str | None = None
+
     @property
     def dtype(self) -> type[int]:
         return int
@@ -35,6 +37,7 @@ class Float(DataType[float]):
     """`DataType` mapping to builtin ``float``."""
 
     prec: int = 2
+    units: str | None = None
 
     @property
     def dtype(self) -> type[float]:

--- a/src/fastcs/datatypes.py
+++ b/src/fastcs/datatypes.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import numpy as np
+from numpy import typing as npt
 from abc import abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
-T = TypeVar("T", int, float, bool, str)
+T = TypeVar("T", int, float, bool, str, npt.ArrayLike)
 ATTRIBUTE_TYPES: tuple[type] = T.__constraints__  # type: ignore
 
 
@@ -72,6 +74,31 @@ class String(DataType[str]):
     @property
     def dtype(self) -> type[str]:
         return str
+
+
+@dataclass(frozen=True)
+class WaveForm(DataType[npt.ArrayLike]):
+    """DataType for a waveform"""
+
+    length: int | None = None
+
+    @property
+    def dtype(self) -> type[npt.ArrayLike]:
+        return np.ndarray
+
+
+@dataclass(frozen=True)
+class Table(DataType[npt.ArrayLike]):
+    """`DataType` mapping to a dictionary of numpy arrays.
+
+    Values should be a dictionary of column name to an `ArrayLike` of columns.
+    """
+
+    numpy_datatype: npt.DTypeLike
+
+    @property
+    def dtype(self) -> type[npt.ArrayLike]:
+        return np.ndarray
 
 
 def validate_value(datatype: DataType[T], value: T) -> T:

--- a/src/fastcs/datatypes.py
+++ b/src/fastcs/datatypes.py
@@ -12,6 +12,7 @@ ATTRIBUTE_TYPES: tuple[type] = T.__constraints__  # type: ignore
 AttrCallback = Callable[[T], Awaitable[None]]
 
 
+@dataclass(frozen=True)  # So that we can type hint with dataclass methods
 class DataType(Generic[T]):
     """Generic datatype mapping to a python type, with additional metadata."""
 

--- a/src/fastcs/datatypes.py
+++ b/src/fastcs/datatypes.py
@@ -26,6 +26,10 @@ class Int(DataType[int]):
     """`DataType` mapping to builtin ``int``."""
 
     units: str | None = None
+    min: int | None = None
+    max: int | None = None
+    min_alarm: int | None = None
+    max_alarm: int | None = None
 
     @property
     def dtype(self) -> type[int]:
@@ -38,6 +42,10 @@ class Float(DataType[float]):
 
     prec: int = 2
     units: str | None = None
+    min: float | None = None
+    max: float | None = None
+    min_alarm: float | None = None
+    max_alarm: float | None = None
 
     @property
     def dtype(self) -> type[float]:
@@ -63,3 +71,15 @@ class String(DataType[str]):
     @property
     def dtype(self) -> type[str]:
         return str
+
+
+def validate_value(datatype: DataType[T], value: T) -> T:
+    """Validate a value against a datatype."""
+
+    if isinstance(datatype, (Int | Float)):
+        assert isinstance(value, (int | float)), f"Value {value} is not a number"
+        if datatype.min is not None and value < datatype.min:
+            raise ValueError(f"Value {value} is less than minimum {datatype.min}")
+        if datatype.max is not None and value > datatype.max:
+            raise ValueError(f"Value {value} is greater than maximum {datatype.max}")
+    return value

--- a/src/fastcs/mapping.py
+++ b/src/fastcs/mapping.py
@@ -52,9 +52,17 @@ def _get_single_mapping(controller: BaseController) -> SingleMapping:
             case WrappedMethod(fastcs_method=Command(enabled=True) as command_method):
                 command_methods[attr_name] = command_method
             case Attribute(enabled=True):
-                attributes[attr_name] = attr
+                if controller.search_device_for_attributes:
+                    attributes[attr_name] = attr
 
-    attributes.update(controller.additional_attributes or {})
+    additional_attributes = controller.additional_attributes
+    if common_attributes := additional_attributes.keys() ^ attributes.keys():
+        raise RuntimeError(
+            f"Received additional attributes {common_attributes} "
+            "already present in the controller."
+        )
+
+    attributes.update(additional_attributes)
 
     return SingleMapping(
         controller, scan_methods, put_methods, command_methods, attributes

--- a/src/fastcs/mapping.py
+++ b/src/fastcs/mapping.py
@@ -54,6 +54,8 @@ def _get_single_mapping(controller: BaseController) -> SingleMapping:
             case Attribute(enabled=True):
                 attributes[attr_name] = attr
 
+    attributes.update(controller.additional_attributes or {})
+
     return SingleMapping(
         controller, scan_methods, put_methods, command_methods, attributes
     )

--- a/src/fastcs/mapping.py
+++ b/src/fastcs/mapping.py
@@ -56,10 +56,10 @@ def _get_single_mapping(controller: BaseController) -> SingleMapping:
                     attributes[attr_name] = attr
 
     additional_attributes = controller.additional_attributes
-    if common_attributes := additional_attributes.keys() ^ attributes.keys():
+    if common_attributes := additional_attributes.keys() & attributes.keys():
         raise RuntimeError(
             f"Received additional attributes {common_attributes} "
-            "already present in the controller."
+            f"already present in the controller {controller}."
         )
 
     attributes.update(additional_attributes)

--- a/tests/backends/epics/test_ioc.py
+++ b/tests/backends/epics/test_ioc.py
@@ -357,7 +357,8 @@ def test_add_attr_pvi_info(mocker: MockerFixture):
     )
 
 
-async def do_nothing(arg): ...
+async def do_nothing(arg):
+    ...
 
 
 class NothingCommand:

--- a/tests/backends/epics/test_ioc.py
+++ b/tests/backends/epics/test_ioc.py
@@ -357,8 +357,7 @@ def test_add_attr_pvi_info(mocker: MockerFixture):
     )
 
 
-async def do_nothing(arg):
-    ...
+async def do_nothing(arg): ...
 
 
 class NothingCommand:

--- a/tests/backends/epics/test_ioc.py
+++ b/tests/backends/epics/test_ioc.py
@@ -233,6 +233,15 @@ def test_get_output_record_raises(mocker: MockerFixture):
         _get_output_record("PV", mocker.MagicMock(), on_update=mocker.MagicMock())
 
 
+DEFAULT_SCALAR_FIELD_ARGS = {
+    "EGU": None,
+    "DRVL": None,
+    "DRVH": None,
+    "LOPR": None,
+    "HOPR": None,
+}
+
+
 def test_ioc(mocker: MockerFixture, mapping: Mapping):
     builder = mocker.patch("fastcs.backends.epics.ioc.builder")
     add_pvi_info = mocker.patch("fastcs.backends.epics.ioc._add_pvi_info")
@@ -244,21 +253,26 @@ def test_ioc(mocker: MockerFixture, mapping: Mapping):
 
     # Check records are created
     builder.boolIn.assert_called_once_with(f"{DEVICE}:ReadBool", ZNAM="OFF", ONAM="ON")
-    builder.longIn.assert_any_call(f"{DEVICE}:ReadInt", EGU=None)
+    builder.longIn.assert_any_call(f"{DEVICE}:ReadInt", **DEFAULT_SCALAR_FIELD_ARGS)
     builder.aIn.assert_called_once_with(
-        f"{DEVICE}:ReadWriteFloat_RBV", EGU=None, PREC=2
+        f"{DEVICE}:ReadWriteFloat_RBV", PREC=2, **DEFAULT_SCALAR_FIELD_ARGS
     )
     builder.aOut.assert_any_call(
         f"{DEVICE}:ReadWriteFloat",
         always_update=True,
         on_update=mocker.ANY,
-        EGU=None,
         PREC=2,
+        **DEFAULT_SCALAR_FIELD_ARGS,
     )
-    builder.longIn.assert_any_call(f"{DEVICE}:BigEnum", EGU=None)
-    builder.longIn.assert_any_call(f"{DEVICE}:ReadWriteInt_RBV", EGU=None)
+    builder.longIn.assert_any_call(f"{DEVICE}:BigEnum", **DEFAULT_SCALAR_FIELD_ARGS)
+    builder.longIn.assert_any_call(
+        f"{DEVICE}:ReadWriteInt_RBV", **DEFAULT_SCALAR_FIELD_ARGS
+    )
     builder.longOut.assert_called_with(
-        f"{DEVICE}:ReadWriteInt", always_update=True, on_update=mocker.ANY, EGU=None
+        f"{DEVICE}:ReadWriteInt",
+        always_update=True,
+        on_update=mocker.ANY,
+        **DEFAULT_SCALAR_FIELD_ARGS,
     )
     builder.mbbIn.assert_called_once_with(
         f"{DEVICE}:StringEnum_RBV", ZRST="red", ONST="green", TWST="blue"
@@ -417,9 +431,14 @@ def test_long_pv_names_discarded(mocker: MockerFixture):
 
     short_pv_name = "attr_rw_short_name".title().replace("_", "")
     builder.longOut.assert_called_once_with(
-        f"{DEVICE}:{short_pv_name}", always_update=True, on_update=mocker.ANY, EGU=None
+        f"{DEVICE}:{short_pv_name}",
+        always_update=True,
+        on_update=mocker.ANY,
+        **DEFAULT_SCALAR_FIELD_ARGS,
     )
-    builder.longIn.assert_called_once_with(f"{DEVICE}:{short_pv_name}_RBV", EGU=None)
+    builder.longIn.assert_called_once_with(
+        f"{DEVICE}:{short_pv_name}_RBV", **DEFAULT_SCALAR_FIELD_ARGS
+    )
 
     long_pv_name = long_attr_name.title().replace("_", "")
     with pytest.raises(AssertionError):

--- a/tests/backends/epics/test_ioc.py
+++ b/tests/backends/epics/test_ioc.py
@@ -7,11 +7,7 @@ from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.backends.epics.ioc import (
     EPICS_MAX_NAME_LENGTH,
     EpicsIOC,
-    _add_attr_pvi_info,
     _add_pvi_info,
-    _add_sub_controller_pvi_info,
-    _create_and_link_read_pv,
-    _create_and_link_write_pv,
     _get_input_record,
     _get_output_record,
 )
@@ -27,17 +23,31 @@ SEVENTEEN_VALUES = [str(i) for i in range(1, 18)]
 ONOFF_STATES = {"ZRST": "disabled", "ONST": "enabled"}
 
 
+@pytest.fixture
+def ioc_without_mapping(mocker: MockerFixture, mapping: Mapping):
+    mocker.patch("fastcs.backends.epics.ioc.builder")
+    mocker.patch("fastcs.backends.epics.ioc.EpicsIOC._create_and_link_attribute_pvs")
+    mocker.patch("fastcs.backends.epics.ioc.EpicsIOC._create_and_link_command_pvs")
+
+    return EpicsIOC(DEVICE, mapping)
+
+
 @pytest.mark.asyncio
-async def test_create_and_link_read_pv(mocker: MockerFixture):
+async def test_create_and_link_read_pv(
+    mocker: MockerFixture, ioc_without_mapping: EpicsIOC
+):
     get_input_record = mocker.patch("fastcs.backends.epics.ioc._get_input_record")
-    add_attr_pvi_info = mocker.patch("fastcs.backends.epics.ioc._add_attr_pvi_info")
     attr_is_enum = mocker.patch("fastcs.backends.epics.ioc.attr_is_enum")
+    mocker.patch("fastcs.backends.epics.ioc._add_pvi_info")
+    add_attr_pvi_info = mocker.patch(
+        "fastcs.backends.epics.ioc.EpicsIOC._add_attr_pvi_info"
+    )
     record = get_input_record.return_value
 
     attribute = mocker.MagicMock()
-
     attr_is_enum.return_value = False
-    _create_and_link_read_pv("PREFIX", "PV", "attr", attribute)
+
+    ioc_without_mapping._create_and_link_read_pv("PREFIX", "PV", "attr", attribute)
 
     get_input_record.assert_called_once_with("PREFIX:PV", attribute)
     add_attr_pvi_info.assert_called_once_with(record, "PREFIX", "attr", "r")
@@ -51,9 +61,13 @@ async def test_create_and_link_read_pv(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_create_and_link_read_pv_enum(mocker: MockerFixture):
+async def test_create_and_link_read_pv_enum(
+    mocker: MockerFixture, ioc_without_mapping: EpicsIOC
+):
     get_input_record = mocker.patch("fastcs.backends.epics.ioc._get_input_record")
-    add_attr_pvi_info = mocker.patch("fastcs.backends.epics.ioc._add_attr_pvi_info")
+    add_attr_pvi_info = mocker.patch(
+        "fastcs.backends.epics.ioc.EpicsIOC._add_attr_pvi_info"
+    )
     attr_is_enum = mocker.patch("fastcs.backends.epics.ioc.attr_is_enum")
     record = get_input_record.return_value
     enum_value_to_index = mocker.patch("fastcs.backends.epics.ioc.enum_value_to_index")
@@ -61,7 +75,7 @@ async def test_create_and_link_read_pv_enum(mocker: MockerFixture):
     attribute = mocker.MagicMock()
 
     attr_is_enum.return_value = True
-    _create_and_link_read_pv("PREFIX", "PV", "attr", attribute)
+    ioc_without_mapping._create_and_link_read_pv("PREFIX", "PV", "attr", attribute)
 
     get_input_record.assert_called_once_with("PREFIX:PV", attribute)
     add_attr_pvi_info.assert_called_once_with(record, "PREFIX", "attr", "r")
@@ -108,9 +122,13 @@ def test_get_input_record_raises(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_create_and_link_write_pv(mocker: MockerFixture):
+async def test_create_and_link_write_pv(
+    mocker: MockerFixture, ioc_without_mapping: EpicsIOC
+):
     get_output_record = mocker.patch("fastcs.backends.epics.ioc._get_output_record")
-    add_attr_pvi_info = mocker.patch("fastcs.backends.epics.ioc._add_attr_pvi_info")
+    add_attr_pvi_info = mocker.patch(
+        "fastcs.backends.epics.ioc.EpicsIOC._add_attr_pvi_info"
+    )
     attr_is_enum = mocker.patch("fastcs.backends.epics.ioc.attr_is_enum")
     record = get_output_record.return_value
 
@@ -118,7 +136,7 @@ async def test_create_and_link_write_pv(mocker: MockerFixture):
     attribute.process_without_display_update = mocker.AsyncMock()
 
     attr_is_enum.return_value = False
-    _create_and_link_write_pv("PREFIX", "PV", "attr", attribute)
+    ioc_without_mapping._create_and_link_write_pv("PREFIX", "PV", "attr", attribute)
 
     get_output_record.assert_called_once_with(
         "PREFIX:PV", attribute, on_update=mocker.ANY
@@ -140,9 +158,13 @@ async def test_create_and_link_write_pv(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_create_and_link_write_pv_enum(mocker: MockerFixture):
+async def test_create_and_link_write_pv_enum(
+    mocker: MockerFixture, ioc_without_mapping: EpicsIOC
+):
     get_output_record = mocker.patch("fastcs.backends.epics.ioc._get_output_record")
-    add_attr_pvi_info = mocker.patch("fastcs.backends.epics.ioc._add_attr_pvi_info")
+    add_attr_pvi_info = mocker.patch(
+        "fastcs.backends.epics.ioc.EpicsIOC._add_attr_pvi_info"
+    )
     attr_is_enum = mocker.patch("fastcs.backends.epics.ioc.attr_is_enum")
     enum_value_to_index = mocker.patch("fastcs.backends.epics.ioc.enum_value_to_index")
     enum_index_to_value = mocker.patch("fastcs.backends.epics.ioc.enum_index_to_value")
@@ -152,7 +174,7 @@ async def test_create_and_link_write_pv_enum(mocker: MockerFixture):
     attribute.process_without_display_update = mocker.AsyncMock()
 
     attr_is_enum.return_value = True
-    _create_and_link_write_pv("PREFIX", "PV", "attr", attribute)
+    ioc_without_mapping._create_and_link_write_pv("PREFIX", "PV", "attr", attribute)
 
     get_output_record.assert_called_once_with(
         "PREFIX:PV", attribute, on_update=mocker.ANY
@@ -215,22 +237,28 @@ def test_ioc(mocker: MockerFixture, mapping: Mapping):
     builder = mocker.patch("fastcs.backends.epics.ioc.builder")
     add_pvi_info = mocker.patch("fastcs.backends.epics.ioc._add_pvi_info")
     add_sub_controller_pvi_info = mocker.patch(
-        "fastcs.backends.epics.ioc._add_sub_controller_pvi_info"
+        "fastcs.backends.epics.ioc.EpicsIOC._add_sub_controller_pvi_info"
     )
 
     EpicsIOC(DEVICE, mapping)
 
     # Check records are created
     builder.boolIn.assert_called_once_with(f"{DEVICE}:ReadBool", ZNAM="OFF", ONAM="ON")
-    builder.longIn.assert_any_call(f"{DEVICE}:ReadInt")
-    builder.aIn.assert_called_once_with(f"{DEVICE}:ReadWriteFloat_RBV", PREC=2)
-    builder.aOut.assert_any_call(
-        f"{DEVICE}:ReadWriteFloat", always_update=True, on_update=mocker.ANY, PREC=2
+    builder.longIn.assert_any_call(f"{DEVICE}:ReadInt", EGU=None)
+    builder.aIn.assert_called_once_with(
+        f"{DEVICE}:ReadWriteFloat_RBV", EGU=None, PREC=2
     )
-    builder.longIn.assert_any_call(f"{DEVICE}:BigEnum")
-    builder.longIn.assert_any_call(f"{DEVICE}:ReadWriteInt_RBV")
+    builder.aOut.assert_any_call(
+        f"{DEVICE}:ReadWriteFloat",
+        always_update=True,
+        on_update=mocker.ANY,
+        EGU=None,
+        PREC=2,
+    )
+    builder.longIn.assert_any_call(f"{DEVICE}:BigEnum", EGU=None)
+    builder.longIn.assert_any_call(f"{DEVICE}:ReadWriteInt_RBV", EGU=None)
     builder.longOut.assert_called_with(
-        f"{DEVICE}:ReadWriteInt", always_update=True, on_update=mocker.ANY
+        f"{DEVICE}:ReadWriteInt", always_update=True, on_update=mocker.ANY, EGU=None
     )
     builder.mbbIn.assert_called_once_with(
         f"{DEVICE}:StringEnum_RBV", ZRST="red", ONST="green", TWST="blue"
@@ -323,7 +351,9 @@ def test_add_pvi_info_with_parent(mocker: MockerFixture):
     )
 
 
-def test_add_sub_controller_pvi_info(mocker: MockerFixture):
+def test_add_sub_controller_pvi_info(
+    mocker: MockerFixture, ioc_without_mapping: EpicsIOC
+):
     add_pvi_info = mocker.patch("fastcs.backends.epics.ioc._add_pvi_info")
     controller = mocker.MagicMock()
     controller.path = []
@@ -331,17 +361,17 @@ def test_add_sub_controller_pvi_info(mocker: MockerFixture):
     child.path = ["Child"]
     controller.get_sub_controllers.return_value = {"d": child}
 
-    _add_sub_controller_pvi_info(DEVICE, controller)
+    ioc_without_mapping._add_sub_controller_pvi_info(DEVICE, controller)
 
     add_pvi_info.assert_called_once_with(
         f"{DEVICE}:Child:PVI", f"{DEVICE}:PVI", "child"
     )
 
 
-def test_add_attr_pvi_info(mocker: MockerFixture):
+def test_add_attr_pvi_info(mocker: MockerFixture, ioc_without_mapping: EpicsIOC):
     record = mocker.MagicMock()
 
-    _add_attr_pvi_info(record, DEVICE, "attr", "r")
+    ioc_without_mapping._add_attr_pvi_info(record, DEVICE, "attr", "r")
 
     record.add_info.assert_called_once_with(
         "Q:group",
@@ -387,13 +417,9 @@ def test_long_pv_names_discarded(mocker: MockerFixture):
 
     short_pv_name = "attr_rw_short_name".title().replace("_", "")
     builder.longOut.assert_called_once_with(
-        f"{DEVICE}:{short_pv_name}",
-        always_update=True,
-        on_update=mocker.ANY,
+        f"{DEVICE}:{short_pv_name}", always_update=True, on_update=mocker.ANY, EGU=None
     )
-    builder.longIn.assert_called_once_with(
-        f"{DEVICE}:{short_pv_name}_RBV",
-    )
+    builder.longIn.assert_called_once_with(f"{DEVICE}:{short_pv_name}_RBV", EGU=None)
 
     long_pv_name = long_attr_name.title().replace("_", "")
     with pytest.raises(AssertionError):

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -1,14 +1,15 @@
 from functools import partial
 
+import numpy as np
 import pytest
 
 from fastcs.attributes import AttrR, AttrRW
-from fastcs.datatypes import Int, String
+from fastcs.datatypes import Int, String, WaveForm
 
 
 @pytest.mark.asyncio
 async def test_attributes():
-    device = {"state": "Idle", "number": 1, "count": False}
+    device = {"state": "Idle", "number": 1, "count": False, "array": None}
     ui = {"state": "", "number": 0, "count": False}
 
     async def update_ui(value, key):
@@ -17,17 +18,30 @@ async def test_attributes():
     async def send(value, key):
         device[key] = value
 
-    async def device_add():
-        device["number"] += 1
-
     attr_r = AttrR(String())
     attr_r.set_update_callback(partial(update_ui, key="state"))
     await attr_r.set(device["state"])
     assert ui["state"] == "Idle"
 
-    attr_rw = AttrRW(Int())
+    attr_rw = AttrRW(Int(max=10))
     attr_rw.set_process_callback(partial(send, key="number"))
     attr_rw.set_write_display_callback(partial(update_ui, key="number"))
-    await attr_rw.process(2)
-    assert device["number"] == 2
-    assert ui["number"] == 2
+    await attr_rw.process(10)
+    assert device["number"] == 10
+    assert ui["number"] == 10
+    with pytest.raises(ValueError):
+        await attr_rw.set(100)
+
+    attr_rw = AttrRW(WaveForm(np.dtype("int32"), 10))
+    attr_rw.set_process_callback(partial(send, key="array"))
+    await attr_rw.process(np.array(range(10), dtype="int32"))
+    assert np.array_equal(device["array"], np.array(range(10), dtype="int32"))
+
+    with pytest.raises(
+        ValueError, match="Waveform length 11 is greater than maximum 10."
+    ):
+        await attr_rw.process(np.array(range(11), dtype="int32"))
+    with pytest.raises(
+        ValueError, match="Waveform dtype float64 does not match int32."
+    ):
+        await attr_rw.process(np.array(range(10), dtype="float64"))

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,4 +1,4 @@
-from time import sleep
+import asyncio
 
 import pytest
 
@@ -16,7 +16,7 @@ class DummyBackend(Backend):
         self.init_task_called = True
 
     def _run(self):
-        pass
+        asyncio.run_coroutine_threadsafe(asyncio.sleep(0.3), self._loop)
 
 
 @pytest.mark.asyncio
@@ -41,5 +41,7 @@ async def test_backend(controller):
     # Scan tasks should be running
     for _ in range(3):
         count = controller.count
-        sleep(0.05)
+        await asyncio.sleep(0.1)
         assert controller.count > count
+
+    backend.stop_scan_tasks()


### PR DESCRIPTION
# Changes

## Attributes
### Mapping
Controllers can now define
``` python
    @property
    def additional_attributes(self) -> dict[str, Attribute]:
        """FastCS will look for attributes on the controller, but additional attributes
        are provided by this method."""
        return {}
```

which is another way to provide attributes without `setattr` on the controller. The keys are checked to be distinct from the attributes found from the attributes of the controller.

The user can also pass in `search_device_for_attributes=False` on the controller which will prevent the mapping automatically searching for `Attributes`, it will only use `additional_attributes`.

### Description
Added a field called `description` to `Attribute`, which is used as `DESC` on the `EPICS` record.

### Initial value
Added an option for `initial_value` on `SignalR`/`SignalRW`. If provided this will be used instead of the default of the `_datatype.dtype` for the initial value of the attribute.

### Changing the datatype
We still want `DataType` to be frozen, but we also might want to change the value of a field in it - e.g `units`, corresponding to `EGU` in the epics backend.

To do this I've made a method called `update_datatype` which will change the `_datatype` of the attribute. This alone wouldn't update the corresponding record, so the backend runs `set_update_databack_callback`. `update_datatype` will then run this so changing the attribute datatype will update the backend.

## Scan Tasks
### Errors
Currently, errors in a scan future will be swallowed. Now an error will be printed.

### Killing Scan Tasks
We were getting problems for scan tasks not being torn down after the end of tests. Now the backend will stop the tasks on `__del__`, or running the new `stop_scan_tasks` method.

## DataTypes
### Methods
Rather than just using `DataType.dtype()` we now have a `DataType.initial_value` property.
We also have a `DataType.cast` which is used to cast inputted values and validated against metadata fields in the datatype.

### Added metadata to the datatype
Added a bunch of optional fields to `String, Int, Float` which are used for relevant fields e.g `HOPR` in the epics backend. `Int` and `Float` `Attributes` are validated against their `max` and `min` on put.

### New Datatypes (PENDING)
#### Waveform
A waveform to correspond to a single pv without any pva structure beyond regular pvi.

#### Table
A waveform which is indexable using pvi PVs generated from names of the columns of the numpy structured datatype. These will be added in a new PVXS backend.

## Epics Backend
### Options
Naming conventions are now passed into the ioc through `EpicsIOCOptions`, which can be passed into the backend on init.

## Handlers
### Poll Period
`update_period` is now optional in fields, designating that the `Updater` shouldn't be ran periodically. In panda we get all the changes at once in the top level `update` scan method. We want to then update all the relevant attributes from there.