### PR TITLE
swapped back to using `Future`s

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -10,7 +10,7 @@ class DummyBackend(Backend):
         super().__init__(controller)
 
         self.init_task_called = False
-        self._initial_tasks.append(self.init_task)
+        self._initial_coros.append(self.init_task)
 
     async def init_task(self):
         self.init_task_called = True
@@ -44,4 +44,4 @@ async def test_backend(controller):
         await asyncio.sleep(0.1)
         assert controller.count > count
 
-    backend.stop_scan_tasks()
+    backend.stop_scan_futures()


### PR DESCRIPTION
```
[:)] python -m fastcs_eiger ioc EIGER
INFO: PVXS QSRV2 is loaded, permitted, and ENABLED.
2024-11-18T16:13:59.846533809 WARN pvxs.tcp.setup Server unable to bind port 5075, falling back to [::]:37927
Starting iocInit
############################################################################
## EPICS 7.0.7.0
## Rev. 7.0.7.99.0.2
## Rev. Date 7.0.7.99.0.2
############################################################################
`update` AFTER 0.3049039840698242
`update` AFTER 0.41122913360595703
```

Futures start at the right time, and closing them with `stop_scan_futures` works the same way.