### PR TITLE
Create ControllerAPI class to decouple transport from Controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 description = "Control system agnostic framework for building Device support in Python that will work for both EPICS and Tango"
 dependencies = [

--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -1,10 +1,12 @@
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable
-from types import MethodType
+
+from fastcs.cs_methods import Command, Put, Scan
 
 from .attributes import AttrR, AttrW, Sender, Updater
-from .controller import Controller, SingleMapping
+from .controller import BaseController, Controller
+from .controller_api import ControllerAPI
 from .exceptions import FastCSException
 
 
@@ -14,19 +16,21 @@ class Backend:
         controller: Controller,
         loop: asyncio.AbstractEventLoop,
     ):
-        self._loop = loop
         self._controller = controller
+        self._loop = loop
 
         self._initial_coros = [controller.connect]
         self._scan_tasks: set[asyncio.Task] = set()
 
-        loop.run_until_complete(self._controller.initialise())
+        # Initialise controller and then build its APIs
+        loop.run_until_complete(controller.initialise())
+        self.controller_api = build_controller_api(controller)
         self._link_process_tasks()
 
     def _link_process_tasks(self):
-        for single_mapping in self._controller.get_controller_mappings():
-            _link_single_controller_put_tasks(single_mapping)
-            _link_attribute_sender_class(single_mapping)
+        for controller_api in self.controller_api.walk_api():
+            _link_put_tasks(controller_api)
+            _link_attribute_sender_class(controller_api, self._controller)
 
     def __del__(self):
         self._stop_scan_tasks()
@@ -41,7 +45,8 @@ class Backend:
 
     async def _start_scan_tasks(self):
         self._scan_tasks = {
-            self._loop.create_task(coro()) for coro in _get_scan_coros(self._controller)
+            self._loop.create_task(coro())
+            for coro in _get_scan_coros(self.controller_api, self._controller)
         }
 
     def _stop_scan_tasks(self):
@@ -53,16 +58,14 @@ class Backend:
                     pass
 
 
-def _link_single_controller_put_tasks(single_mapping: SingleMapping) -> None:
-    for name, method in single_mapping.put_methods.items():
+def _link_put_tasks(controller_api: ControllerAPI) -> None:
+    for name, method in controller_api.put_methods.items():
         name = name.removeprefix("put_")
 
-        attribute = single_mapping.attributes[name]
+        attribute = controller_api.attributes[name]
         match attribute:
             case AttrW():
-                attribute.set_process_callback(
-                    MethodType(method.fn, single_mapping.controller)
-                )
+                attribute.set_process_callback(method.fn)
             case _:
                 raise FastCSException(
                     f"Mode {attribute.access_mode} does not "
@@ -70,15 +73,17 @@ def _link_single_controller_put_tasks(single_mapping: SingleMapping) -> None:
                 )
 
 
-def _link_attribute_sender_class(single_mapping: SingleMapping) -> None:
-    for attr_name, attribute in single_mapping.attributes.items():
+def _link_attribute_sender_class(
+    controller_api: ControllerAPI, controller: Controller
+) -> None:
+    for attr_name, attribute in controller_api.attributes.items():
         match attribute:
             case AttrW(sender=Sender()):
                 assert not attribute.has_process_callback(), (
                     f"Cannot assign both put method and Sender object to {attr_name}"
                 )
 
-                callback = _create_sender_callback(attribute, single_mapping.controller)
+                callback = _create_sender_callback(attribute, controller)
                 attribute.set_process_callback(callback)
 
 
@@ -89,35 +94,35 @@ def _create_sender_callback(attribute, controller):
     return callback
 
 
-def _get_scan_coros(controller: Controller) -> list[Callable]:
+def _get_scan_coros(
+    root_controller_api: ControllerAPI, controller: Controller
+) -> list[Callable]:
     scan_dict: dict[float, list[Callable]] = defaultdict(list)
 
-    for single_mapping in controller.get_controller_mappings():
-        _add_scan_method_tasks(scan_dict, single_mapping)
-        _add_attribute_updater_tasks(scan_dict, single_mapping)
+    for controller_api in root_controller_api.walk_api():
+        _add_scan_method_tasks(scan_dict, controller_api)
+        _add_attribute_updater_tasks(scan_dict, controller_api, controller)
 
     scan_coros = _get_periodic_scan_coros(scan_dict)
     return scan_coros
 
 
 def _add_scan_method_tasks(
-    scan_dict: dict[float, list[Callable]], single_mapping: SingleMapping
+    scan_dict: dict[float, list[Callable]], controller_api: ControllerAPI
 ):
-    for method in single_mapping.scan_methods.values():
-        scan_dict[method.period].append(
-            MethodType(method.fn, single_mapping.controller)
-        )
+    for method in controller_api.scan_methods.values():
+        scan_dict[method.period].append(method.fn)
 
 
 def _add_attribute_updater_tasks(
-    scan_dict: dict[float, list[Callable]], single_mapping: SingleMapping
+    scan_dict: dict[float, list[Callable]],
+    controller_api: ControllerAPI,
+    controller: Controller,
 ):
-    for attribute in single_mapping.attributes.values():
+    for attribute in controller_api.attributes.values():
         match attribute:
             case AttrR(updater=Updater(update_period=update_period)) as attribute:
-                callback = _create_updater_callback(
-                    attribute, single_mapping.controller
-                )
+                callback = _create_updater_callback(attribute, controller)
                 if update_period is not None:
                     scan_dict[update_period].append(callback)
 
@@ -155,3 +160,38 @@ def _create_periodic_scan_coro(period, methods: list[Callable]) -> Callable:
             await asyncio.gather(*[method() for method in methods])
 
     return scan_coro
+
+
+def build_controller_api(controller: Controller) -> ControllerAPI:
+    return _build_controller_api(controller, [])
+
+
+def _build_controller_api(controller: BaseController, path: list[str]) -> ControllerAPI:
+    """Build a `ControllerAPI` for a `BaseController` and its sub controllers"""
+    scan_methods: dict[str, Scan] = {}
+    put_methods: dict[str, Put] = {}
+    command_methods: dict[str, Command] = {}
+    for attr_name in dir(controller):
+        attr = getattr(controller, attr_name)
+        match attr:
+            case Put(enabled=True):
+                put_methods[attr_name] = attr
+            case Scan(enabled=True):
+                scan_methods[attr_name] = attr
+            case Command(enabled=True):
+                command_methods[attr_name] = attr
+            case _:
+                pass
+
+    return ControllerAPI(
+        path=path,
+        attributes=controller.attributes,
+        command_methods=command_methods,
+        put_methods=put_methods,
+        scan_methods=scan_methods,
+        sub_apis={
+            name: _build_controller_api(sub_controller, path + [name])
+            for name, sub_controller in controller.get_sub_controllers().items()
+        },
+        description=controller.description,
+    )

--- a/src/fastcs/controller_api.py
+++ b/src/fastcs/controller_api.py
@@ -1,0 +1,31 @@
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+from fastcs.attributes import Attribute
+from fastcs.cs_methods import Command, Put, Scan
+
+
+@dataclass
+class ControllerAPI:
+    """Attributes, bound methods and sub APIs of a `Controller` / `SubController`"""
+
+    path: list[str] = field(default_factory=list)
+    """Path within controller tree (empty if this is the root)"""
+    attributes: dict[str, Attribute] = field(default_factory=dict)
+    command_methods: dict[str, Command] = field(default_factory=dict)
+    put_methods: dict[str, Put] = field(default_factory=dict)
+    scan_methods: dict[str, Scan] = field(default_factory=dict)
+    sub_apis: dict[str, "ControllerAPI"] = field(default_factory=dict)
+    """APIs of the sub controllers of the `Controller` this API was built from"""
+    description: str | None = None
+
+    def walk_api(self) -> Iterator["ControllerAPI"]:
+        """Walk through all the nested `ControllerAPIs` of this `ControllerAPI`
+
+        yields: `ControllerAPI`s from a depth-first traversal of the tree, including
+        self.
+
+        """
+        yield self
+        for api in self.sub_apis.values():
+            yield from api.walk_api()

--- a/src/fastcs/cs_methods.py
+++ b/src/fastcs/cs_methods.py
@@ -1,14 +1,40 @@
 from asyncio import iscoroutinefunction
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from inspect import Signature, getdoc, signature
+from types import MethodType
+from typing import Any, Generic, TypeVar
+
+from fastcs.controller import BaseController
 
 from .exceptions import FastCSException
 
-ScanCallback = Callable[..., Awaitable[None]]
+MethodCallback = Callable[..., Coroutine[None, None, None]]
+"""Generic base class for all `Controller` methods"""
+Controller_T = TypeVar("Controller_T", bound=BaseController)
+"""Generic `Controller` class that an unbound method must be called with as `self`"""
+UnboundCommandCallback = Callable[[Controller_T], Coroutine[None, None, None]]
+"""A Command callback that is unbound and must be called with a `Controller` instance"""
+UnboundScanCallback = Callable[[Controller_T], Coroutine[None, None, None]]
+"""A Scan callback that is unbound and must be called with a `Controller` instance"""
+UnboundPutCallback = Callable[[Controller_T, Any], Coroutine[None, None, None]]
+"""A Put callback that is unbound and must be called with a `Controller` instance"""
+CommandCallback = Callable[[], Coroutine[None, None, None]]
+"""A Command callback that is bound and can be called without `self`"""
+ScanCallback = Callable[[], Coroutine[None, None, None]]
+"""A Scan callback that is bound and can be called withous `self`"""
+PutCallback = Callable[[Any], Coroutine[None, None, None]]
+"""A Put callback that is bound and can be called without `self`"""
 
 
-class Method:
-    def __init__(self, fn: Callable, *, group: str | None = None) -> None:
+method_not_bound_error = NotImplementedError(
+    "Method must be bound to a controller instance to be callable"
+)
+
+
+class Method(Generic[Controller_T]):
+    """Generic base class for all FastCS Controller methods."""
+
+    def __init__(self, fn: MethodCallback, *, group: str | None = None) -> None:
         self._docstring = getdoc(fn)
 
         sig = signature(fn, eval_str=True)
@@ -20,7 +46,7 @@ class Method:
         self._group = group
         self.enabled = True
 
-    def _validate(self, fn: Callable) -> None:
+    def _validate(self, fn: MethodCallback) -> None:
         if self.return_type not in (None, Signature.empty):
             raise FastCSException("Method return type must be None or empty")
 
@@ -48,40 +74,142 @@ class Method:
         return self._group
 
 
-class Scan(Method):
-    def __init__(self, fn: Callable, period) -> None:
+class Command(Method[BaseController]):
+    """A `Controller` `Method` that performs a single action when called.
+
+    This class contains a function that is bound to a specific `Controller` instance and
+    is callable outside of the class context, without an explicit `self` parameter.
+    Calling an instance of this class will call the bound `Controller` method.
+    """
+
+    def __init__(self, fn: CommandCallback, *, group: str | None = None):
+        super().__init__(fn, group=group)
+
+    def _validate(self, fn: CommandCallback) -> None:
+        super()._validate(fn)
+
+        if not len(self.parameters) == 0:
+            raise FastCSException(f"Command method cannot have arguments: {fn}")
+
+    async def __call__(self):
+        return await self._fn()
+
+
+class Scan(Method[BaseController]):
+    """A `Controller` `Method` that will be called periodically in the background.
+
+    This class contains a function that is bound to a specific `Controller` instance and
+    is callable outside of the class context, without an explicit `self` parameter.
+    Calling an instance of this class will call the bound `Controller` method.
+    """
+
+    def __init__(self, fn: ScanCallback, period: float):
         super().__init__(fn)
 
         self._period = period
-
-    def _validate(self, fn: Callable) -> None:
-        super()._validate(fn)
-
-        if not len(self.parameters) == 1:
-            raise FastCSException("Scan method cannot have arguments")
 
     @property
     def period(self):
         return self._period
 
+    def _validate(self, fn: ScanCallback) -> None:
+        super()._validate(fn)
 
-class Put(Method):
-    def __init__(self, fn: Callable) -> None:
+        if not len(self.parameters) == 0:
+            raise FastCSException("Scan method cannot have arguments")
+
+    async def __call__(self):
+        return await self._fn()
+
+
+class Put(Method[BaseController]):
+    def __init__(self, fn: PutCallback):
         super().__init__(fn)
 
-    def _validate(self, fn: Callable) -> None:
+    def _validate(self, fn: PutCallback) -> None:
+        super()._validate(fn)
+
+        if not len(self.parameters) == 1:
+            raise FastCSException("Put method can only take one argument")
+
+    async def __call__(self, value: Any):
+        return await self._fn(value)
+
+
+class UnboundCommand(Method[Controller_T]):
+    """A wrapper of an unbound `Controller` method to be bound into a `Command`.
+
+    This generic class stores an unbound `Controller` method - effectively a function
+    that takes an instance of a specific `Controller` type (`Controller_T`). Instances
+    of this class can be added at `Controller` definition, either manually or with use
+    of the `@command` wrapper, to register the method to be included in the API of the
+    `Controller`. When the `Controller` is instantiated, these instances will be bound
+    to the instance, creating a `Command` instance.
+    """
+
+    def __init__(
+        self, fn: UnboundCommandCallback[Controller_T], *, group: str | None = None
+    ) -> None:
+        super().__init__(fn, group=group)
+
+    def _validate(self, fn: UnboundCommandCallback[Controller_T]) -> None:
+        super()._validate(fn)
+
+        if not len(self.parameters) == 1:
+            raise FastCSException("Command method cannot have arguments")
+
+    def bind(self, controller: Controller_T) -> Command:
+        return Command(MethodType(self.fn, controller))
+
+    def __call__(self):
+        raise method_not_bound_error
+
+
+class UnboundScan(Method[Controller_T]):
+    """A wrapper of an unbound `Controller` method to be bound into a `Scan`.
+
+    This generic class stores an unbound `Controller` method - effectively a function
+    that takes an instance of a specific `Controller` type (`Controller_T`). Instances
+    of this class can be added at `Controller` definition, either manually or with use
+    of the `@scan` wrapper, to register the method to be included in the API of the
+    `Controller`. When the `Controller` is instantiated, these instances will be bound
+    to the instance, creating a `Scan` instance.
+    """
+
+    def __init__(self, fn: UnboundScanCallback[Controller_T], period: float) -> None:
+        super().__init__(fn)
+
+        self._period = period
+
+    @property
+    def period(self):
+        return self._period
+
+    def _validate(self, fn: UnboundScanCallback[Controller_T]) -> None:
+        super()._validate(fn)
+
+        if not len(self.parameters) == 1:
+            raise FastCSException("Scan method cannot have arguments")
+
+    def bind(self, controller: Controller_T) -> Scan:
+        return Scan(MethodType(self.fn, controller), self._period)
+
+    def __call__(self):
+        raise method_not_bound_error
+
+
+class UnboundPut(Method[Controller_T]):
+    def __init__(self, fn: UnboundPutCallback[Controller_T]) -> None:
+        super().__init__(fn)
+
+    def _validate(self, fn: UnboundPutCallback[Controller_T]) -> None:
         super()._validate(fn)
 
         if not len(self.parameters) == 2:
             raise FastCSException("Put method can only take one argument")
 
+    def bind(self, controller: Controller_T) -> Put:
+        return Put(MethodType(self.fn, controller))
 
-class Command(Method):
-    def __init__(self, fn: Callable, *, group: str | None = None) -> None:
-        super().__init__(fn, group=group)
-
-    def _validate(self, fn: Callable) -> None:
-        super()._validate(fn)
-
-        if not len(self.parameters) == 1:
-            raise FastCSException("Command method cannot have arguments")
+    def __call__(self):
+        raise method_not_bound_error

--- a/src/fastcs/launch.py
+++ b/src/fastcs/launch.py
@@ -43,14 +43,14 @@ class FastCS:
                     from .transport.epics.pva.adapter import EpicsPVATransport
 
                     transport = EpicsPVATransport(
-                        controller,
+                        self._backend.controller_api,
                         option,
                     )
                 case EpicsCAOptions():
                     from .transport.epics.ca.adapter import EpicsCATransport
 
                     transport = EpicsCATransport(
-                        controller,
+                        self._backend.controller_api,
                         self._loop,
                         option,
                     )
@@ -58,7 +58,7 @@ class FastCS:
                     from .transport.tango.adapter import TangoTransport
 
                     transport = TangoTransport(
-                        controller,
+                        self._backend.controller_api,
                         self._loop,
                         option,
                     )
@@ -66,14 +66,14 @@ class FastCS:
                     from .transport.rest.adapter import RestTransport
 
                     transport = RestTransport(
-                        controller,
+                        self._backend.controller_api,
                         option,
                     )
                 case GraphQLOptions():
                     from .transport.graphQL.adapter import GraphQLTransport
 
                     transport = GraphQLTransport(
-                        controller,
+                        self._backend.controller_api,
                         option,
                     )
 

--- a/src/fastcs/transport/epics/ca/adapter.py
+++ b/src/fastcs/transport/epics/ca/adapter.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from fastcs.controller import Controller
+from fastcs.controller_api import ControllerAPI
 from fastcs.transport.adapter import TransportAdapter
 from fastcs.transport.epics.ca.ioc import EpicsCAIOC
 from fastcs.transport.epics.ca.options import EpicsCAOptions
@@ -11,17 +11,17 @@ from fastcs.transport.epics.gui import EpicsGUI
 class EpicsCATransport(TransportAdapter):
     def __init__(
         self,
-        controller: Controller,
+        controller_api: ControllerAPI,
         loop: asyncio.AbstractEventLoop,
         options: EpicsCAOptions | None = None,
     ) -> None:
-        self._controller = controller
+        self._controller_api = controller_api
         self._loop = loop
         self._options = options or EpicsCAOptions()
         self._pv_prefix = self.options.ioc.pv_prefix
         self._ioc = EpicsCAIOC(
             self.options.ioc.pv_prefix,
-            controller,
+            controller_api,
             self._options.ioc,
         )
 
@@ -30,10 +30,10 @@ class EpicsCATransport(TransportAdapter):
         return self._options
 
     def create_docs(self) -> None:
-        EpicsDocs(self._controller).create_docs(self.options.docs)
+        EpicsDocs(self._controller_api).create_docs(self.options.docs)
 
     def create_gui(self) -> None:
-        EpicsGUI(self._controller, self._pv_prefix).create_gui(self.options.gui)
+        EpicsGUI(self._controller_api, self._pv_prefix).create_gui(self.options.gui)
 
     async def serve(self) -> None:
         print(f"Running FastCS IOC: {self._pv_prefix}")

--- a/src/fastcs/transport/epics/docs.py
+++ b/src/fastcs/transport/epics/docs.py
@@ -1,11 +1,11 @@
-from fastcs.controller import Controller
+from fastcs.controller_api import ControllerAPI
 
 from .options import EpicsDocsOptions
 
 
 class EpicsDocs:
-    def __init__(self, controller: Controller) -> None:
-        self._controller = controller
+    def __init__(self, controller_apis: ControllerAPI) -> None:
+        self._controller_apis = controller_apis
 
     def create_docs(self, options: EpicsDocsOptions | None = None) -> None:
         if options is None:

--- a/src/fastcs/transport/epics/pva/_pv_handlers.py
+++ b/src/fastcs/transport/epics/pva/_pv_handlers.py
@@ -1,5 +1,3 @@
-from collections.abc import Callable
-
 import numpy as np
 from p4p import Value
 from p4p.nt import NTEnum, NTNDArray, NTScalar, NTTable
@@ -9,6 +7,7 @@ from p4p.server import ServerOperation
 from p4p.server.asyncio import SharedPV
 
 from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW
+from fastcs.cs_methods import CommandCallback
 from fastcs.datatypes import Table
 
 from .types import (
@@ -52,7 +51,7 @@ class WritePvHandler:
 
 
 class CommandPvHandler:
-    def __init__(self, command: Callable):
+    def __init__(self, command: CommandCallback):
         self._command = command
         self._task_in_progress = False
 
@@ -125,7 +124,7 @@ def make_shared_pv(attribute: Attribute) -> SharedPV:
     return shared_pv
 
 
-def make_command_pv(command: Callable) -> SharedPV:
+def make_command_pv(command: CommandCallback) -> SharedPV:
     type_ = NTScalar.buildType("?", display=True, control=True)
 
     initial = Value(type_, {"value": False, **p4p_alarm_states()})

--- a/src/fastcs/transport/epics/pva/adapter.py
+++ b/src/fastcs/transport/epics/pva/adapter.py
@@ -1,4 +1,4 @@
-from fastcs.controller import Controller
+from fastcs.controller_api import ControllerAPI
 from fastcs.transport.adapter import TransportAdapter
 from fastcs.transport.epics.docs import EpicsDocs
 from fastcs.transport.epics.gui import EpicsGUI
@@ -10,13 +10,13 @@ from .ioc import P4PIOC
 class EpicsPVATransport(TransportAdapter):
     def __init__(
         self,
-        controller: Controller,
+        controller_api: ControllerAPI,
         options: EpicsPVAOptions | None = None,
     ) -> None:
-        self._controller = controller
+        self._controller_api = controller_api
         self._options = options or EpicsPVAOptions()
         self._pv_prefix = self.options.ioc.pv_prefix
-        self._ioc = P4PIOC(self.options.ioc.pv_prefix, controller)
+        self._ioc = P4PIOC(self.options.ioc.pv_prefix, controller_api)
 
     @property
     def options(self) -> EpicsPVAOptions:
@@ -27,7 +27,7 @@ class EpicsPVATransport(TransportAdapter):
         await self._ioc.run()
 
     def create_docs(self) -> None:
-        EpicsDocs(self._controller).create_docs(self.options.docs)
+        EpicsDocs(self._controller_api).create_docs(self.options.docs)
 
     def create_gui(self) -> None:
-        EpicsGUI(self._controller, self._pv_prefix).create_gui(self.options.gui)
+        EpicsGUI(self._controller_api, self._pv_prefix).create_gui(self.options.gui)

--- a/src/fastcs/transport/epics/pva/ioc.py
+++ b/src/fastcs/transport/epics/pva/ioc.py
@@ -1,11 +1,10 @@
 import asyncio
 import re
-from types import MethodType
 
 from p4p.server import Server, StaticProvider
 
 from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW
-from fastcs.controller import Controller
+from fastcs.controller_api import ControllerAPI
 
 from ._pv_handlers import make_command_pv, make_shared_pv
 from .pvi_tree import AccessModeType, PviTree
@@ -36,31 +35,25 @@ def get_pv_name(pv_prefix: str, *attribute_names: str) -> str:
 
 
 async def parse_attributes(
-    root_pv_prefix: str, controller: Controller
+    root_pv_prefix: str, root_controller_api: ControllerAPI
 ) -> list[StaticProvider]:
     pvi_tree = PviTree(root_pv_prefix)
     provider = StaticProvider(root_pv_prefix)
 
-    for single_mapping in controller.get_controller_mappings():
-        path = single_mapping.controller.path
-        pv_prefix = get_pv_name(root_pv_prefix, *path)
+    for controller_api in root_controller_api.walk_api():
+        pv_prefix = get_pv_name(root_pv_prefix, *controller_api.path)
 
-        pvi_tree.add_sub_device(
-            pv_prefix,
-            single_mapping.controller.description,
-        )
+        pvi_tree.add_sub_device(pv_prefix, controller_api.description)
 
-        for attr_name, attribute in single_mapping.attributes.items():
+        for attr_name, attribute in controller_api.attributes.items():
             pv_name = get_pv_name(pv_prefix, attr_name)
             attribute_pv = make_shared_pv(attribute)
             provider.add(pv_name, attribute_pv)
             pvi_tree.add_signal(pv_name, _attribute_to_access(attribute))
 
-        for attr_name, method in single_mapping.command_methods.items():
+        for attr_name, method in controller_api.command_methods.items():
             pv_name = get_pv_name(pv_prefix, attr_name)
-            command_pv = make_command_pv(
-                MethodType(method.fn, single_mapping.controller)
-            )
+            command_pv = make_command_pv(method.fn)
             provider.add(pv_name, command_pv)
             pvi_tree.add_signal(pv_name, "x")
 
@@ -68,16 +61,12 @@ async def parse_attributes(
 
 
 class P4PIOC:
-    def __init__(
-        self,
-        pv_prefix: str,
-        controller: Controller,
-    ):
+    def __init__(self, pv_prefix: str, controller_api: ControllerAPI):
         self.pv_prefix = pv_prefix
-        self.controller = controller
+        self.controller_api = controller_api
 
     async def run(self):
-        providers = await parse_attributes(self.pv_prefix, self.controller)
+        providers = await parse_attributes(self.pv_prefix, self.controller_api)
 
         endless_event = asyncio.Event()
         with Server(providers):

--- a/src/fastcs/transport/graphQL/adapter.py
+++ b/src/fastcs/transport/graphQL/adapter.py
@@ -1,4 +1,4 @@
-from fastcs.controller import Controller
+from fastcs.controller_api import ControllerAPI
 from fastcs.transport.adapter import TransportAdapter
 
 from .graphQL import GraphQLServer
@@ -8,11 +8,11 @@ from .options import GraphQLOptions
 class GraphQLTransport(TransportAdapter):
     def __init__(
         self,
-        controller: Controller,
+        controller_api: ControllerAPI,
         options: GraphQLOptions | None = None,
     ):
         self._options = options or GraphQLOptions()
-        self._server = GraphQLServer(controller)
+        self._server = GraphQLServer(controller_api)
 
     @property
     def options(self) -> GraphQLOptions:

--- a/src/fastcs/transport/rest/adapter.py
+++ b/src/fastcs/transport/rest/adapter.py
@@ -1,4 +1,4 @@
-from fastcs.controller import Controller
+from fastcs.controller_api import ControllerAPI
 from fastcs.transport.adapter import TransportAdapter
 
 from .options import RestOptions
@@ -8,11 +8,11 @@ from .rest import RestServer
 class RestTransport(TransportAdapter):
     def __init__(
         self,
-        controller: Controller,
+        controller_api: ControllerAPI,
         options: RestOptions | None = None,
     ):
         self._options = options or RestOptions()
-        self._server = RestServer(controller)
+        self._server = RestServer(controller_api)
 
     @property
     def options(self) -> RestOptions:

--- a/src/fastcs/transport/tango/adapter.py
+++ b/src/fastcs/transport/tango/adapter.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from fastcs.controller import Controller
+from fastcs.controller_api import ControllerAPI
 from fastcs.transport.adapter import TransportAdapter
 
 from .dsr import TangoDSR
@@ -10,12 +10,12 @@ from .options import TangoOptions
 class TangoTransport(TransportAdapter):
     def __init__(
         self,
-        controller: Controller,
+        controller_api: ControllerAPI,
         loop: asyncio.AbstractEventLoop,
         options: TangoOptions | None = None,
     ):
         self._options = options or TangoOptions()
-        self._dsr = TangoDSR(controller, loop)
+        self._dsr = TangoDSR(controller_api, loop)
 
     @property
     def options(self) -> TangoOptions:

--- a/tests/benchmarking/controller.py
+++ b/tests/benchmarking/controller.py
@@ -8,7 +8,7 @@ from fastcs.transport.rest.options import RestOptions, RestServerOptions
 from fastcs.transport.tango.options import TangoDSROptions, TangoOptions
 
 
-class TestController(Controller):
+class MyTestController(Controller):
     read_int: AttrR = AttrR(Int(), initial_value=0)
     write_bool: AttrW = AttrW(Bool())
 
@@ -22,7 +22,7 @@ def run():
         TangoOptions(dsr=TangoDSROptions(dev_name="MY/BENCHMARK/DEVICE")),
     ]
     instance = FastCS(
-        TestController(),
+        MyTestController(),
         transport_options,
     )
     instance.run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,11 @@ import pytest
 from aioca import purge_channel_caches
 
 from fastcs.attributes import AttrR, AttrRW, AttrW
+from fastcs.backend import build_controller_api
 from fastcs.datatypes import Bool, Float, Int, String
 from fastcs.transport.tango.dsr import register_dev
 from tests.assertable_controller import (
-    TestController,
+    MyTestController,
     TestHandler,
     TestSender,
     TestUpdater,
@@ -31,7 +32,7 @@ from tests.example_softioc import run as _run_softioc
 DATA_PATH = Path(__file__).parent / "data"
 
 
-class BackendTestController(TestController):
+class BackendTestController(MyTestController):
     read_int: AttrR = AttrR(Int(), handler=TestUpdater())
     read_write_int: AttrRW = AttrRW(Int(), handler=TestHandler())
     read_write_float: AttrRW = AttrRW(Float())
@@ -43,6 +44,11 @@ class BackendTestController(TestController):
 @pytest.fixture
 def controller():
     return BackendTestController()
+
+
+@pytest.fixture
+def controller_api(controller):
+    return build_controller_api(controller)
 
 
 @pytest.fixture

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,11 @@
 import asyncio
 
-from fastcs.backend import Backend
+from fastcs.attributes import AttrRW
+from fastcs.backend import Backend, build_controller_api
+from fastcs.controller import Controller
+from fastcs.cs_methods import Command
+from fastcs.datatypes import Int
+from fastcs.wrappers import command, scan
 
 
 def test_backend(controller):
@@ -27,5 +32,60 @@ def test_backend(controller):
             await asyncio.sleep(0.01)
             assert controller.count > count
         backend._stop_scan_tasks()
+
+    loop.run_until_complete(test_wrapper())
+
+
+def test_controller_api():
+    class MyTestController(Controller):
+        attr1: AttrRW[int] = AttrRW(Int())
+
+        def __init__(self):
+            super().__init__(description="Controller for testing")
+
+            self.attributes["attr2"] = AttrRW(Int())
+
+        @command()
+        async def do_nothing(self):
+            pass
+
+        @scan(1.0)
+        async def scan_nothing(self):
+            pass
+
+    controller = MyTestController()
+    api = build_controller_api(controller)
+
+    assert api.description == controller.description
+    assert list(api.attributes) == ["attr1", "attr2"]
+    assert list(api.command_methods) == ["do_nothing"]
+    assert list(api.scan_methods) == ["scan_nothing"]
+
+
+def test_controller_api_methods():
+    class MyTestController(Controller):
+        def __init__(self):
+            super().__init__()
+
+        async def initialise(self):
+            async def do_nothing_dynamic() -> None:
+                pass
+
+            self.do_nothing_dynamic = Command(do_nothing_dynamic)
+
+        @command()
+        async def do_nothing_static(self):
+            pass
+
+    controller = MyTestController()
+    loop = asyncio.get_event_loop()
+    backend = Backend(controller, loop)
+
+    async def test_wrapper():
+        await controller.do_nothing_static()
+        await controller.do_nothing_dynamic()
+
+        await backend.controller_api.command_methods["do_nothing_static"]()
+        await backend.controller_api.command_methods["do_nothing_dynamic"]()
 
     loop.run_until_complete(test_wrapper())

--- a/tests/test_cs_methods.py
+++ b/tests/test_cs_methods.py
@@ -1,0 +1,115 @@
+import pytest
+
+from fastcs.controller import Controller
+from fastcs.cs_methods import (
+    Command,
+    Method,
+    Put,
+    Scan,
+    UnboundCommand,
+    UnboundPut,
+    UnboundScan,
+)
+from fastcs.exceptions import FastCSException
+
+
+def test_method():
+    def sync_do_nothing():
+        pass
+
+    with pytest.raises(FastCSException):
+        Method(sync_do_nothing)  # type: ignore
+
+    async def do_nothing_with_return() -> int:
+        return 1
+
+    with pytest.raises(FastCSException):
+        Method(do_nothing_with_return)  # type: ignore
+
+    async def do_nothing():
+        """Do nothing."""
+        pass
+
+    method = Method(do_nothing, group="Nothing")
+
+    assert method.docstring == "Do nothing."
+    assert method.group == "Nothing"
+
+
+@pytest.mark.asyncio
+async def test_unbound_command():
+    class TestController(Controller):
+        async def do_nothing(self):
+            pass
+
+        async def do_nothing_with_arg(self, arg):
+            pass
+
+    unbound_command = UnboundCommand(TestController.do_nothing)
+
+    with pytest.raises(NotImplementedError):
+        await unbound_command()
+
+    with pytest.raises(FastCSException):
+        UnboundCommand(TestController.do_nothing_with_arg)  # type: ignore
+
+    with pytest.raises(FastCSException):
+        Command(TestController().do_nothing_with_arg)  # type: ignore
+
+    command = unbound_command.bind(TestController())
+
+    await command()
+
+
+@pytest.mark.asyncio
+async def test_unbound_scan():
+    class TestController(Controller):
+        async def update_nothing(self):
+            pass
+
+        async def update_nothing_with_arg(self, arg):
+            pass
+
+    unbound_scan = UnboundScan(TestController.update_nothing, 1.0)
+
+    assert unbound_scan.period == 1.0
+
+    with pytest.raises(NotImplementedError):
+        await unbound_scan()
+
+    with pytest.raises(FastCSException):
+        UnboundScan(TestController.update_nothing_with_arg, 1.0)  # type: ignore
+
+    with pytest.raises(FastCSException):
+        Scan(TestController().update_nothing_with_arg, 1.0)  # type: ignore
+
+    scan = unbound_scan.bind(TestController())
+
+    assert scan.period == 1.0
+
+    await scan()
+
+
+@pytest.mark.asyncio
+async def test_unbound_put():
+    class TestController(Controller):
+        async def put_value(self, value):
+            pass
+
+        async def put_no_value(self):
+            pass
+
+    unbound_put = UnboundPut(TestController.put_value)
+
+    with pytest.raises(NotImplementedError):
+        await unbound_put()
+
+    with pytest.raises(FastCSException):
+        UnboundPut(TestController.put_no_value)  # type: ignore
+
+    with pytest.raises(FastCSException):
+        Put(TestController().put_no_value)  # type: ignore
+
+    put = unbound_put.bind(TestController())
+
+    await put(1)

--- a/tests/transport/rest/test_rest.py
+++ b/tests/transport/rest/test_rest.py
@@ -5,18 +5,20 @@ import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from tests.assertable_controller import (
-    AssertableController,
+    AssertableControllerAPI,
+    MyTestController,
     TestHandler,
     TestSender,
     TestUpdater,
 )
 
 from fastcs.attributes import AttrR, AttrRW, AttrW
+from fastcs.controller_api import ControllerAPI
 from fastcs.datatypes import Bool, Enum, Float, Int, String, Waveform
 from fastcs.transport.rest.adapter import RestTransport
 
 
-class RestAssertableController(AssertableController):
+class RestController(MyTestController):
     read_int = AttrR(Int(), handler=TestUpdater())
     read_write_int = AttrRW(Int(), handler=TestHandler())
     read_write_float = AttrRW(Float())
@@ -29,126 +31,155 @@ class RestAssertableController(AssertableController):
 
 
 @pytest.fixture(scope="class")
-def assertable_controller(class_mocker: MockerFixture):
-    return RestAssertableController(class_mocker)
+def rest_controller_api(class_mocker: MockerFixture):
+    return AssertableControllerAPI(RestController(), class_mocker)
+
+
+def create_test_client(rest_controller_api: ControllerAPI) -> TestClient:
+    return TestClient(RestTransport(rest_controller_api)._server._app)
 
 
 class TestRestServer:
     @pytest.fixture(scope="class")
-    def client(self, assertable_controller):
-        app = RestTransport(assertable_controller)._server._app
-        with TestClient(app) as client:
-            yield client
+    def test_client(self, rest_controller_api):
+        with create_test_client(rest_controller_api) as test_client:
+            yield test_client
 
-    def test_read_write_int(self, assertable_controller, client):
+    def test_read_write_int(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["read_write_int"]):
-            response = client.get("/read-write-int")
+        with rest_controller_api.assert_read_here(["read_write_int"]):
+            response = test_client.get("/read-write-int")
         assert response.status_code == 200
         assert response.json()["value"] == expect
         new = 9
-        with assertable_controller.assert_write_here(["read_write_int"]):
-            response = client.put("/read-write-int", json={"value": new})
-        assert client.get("/read-write-int").json()["value"] == new
+        with rest_controller_api.assert_write_here(["read_write_int"]):
+            response = test_client.put("/read-write-int", json={"value": new})
+        assert test_client.get("/read-write-int").json()["value"] == new
 
-    def test_read_int(self, assertable_controller, client):
+    def test_read_int(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["read_int"]):
-            response = client.get("/read-int")
+        with rest_controller_api.assert_read_here(["read_int"]):
+            response = test_client.get("/read-int")
         assert response.status_code == 200
         assert response.json()["value"] == expect
 
-    def test_read_write_float(self, assertable_controller, client):
+    def test_read_write_float(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["read_write_float"]):
-            response = client.get("/read-write-float")
+        with rest_controller_api.assert_read_here(["read_write_float"]):
+            response = test_client.get("/read-write-float")
         assert response.status_code == 200
         assert response.json()["value"] == expect
         new = 0.5
-        with assertable_controller.assert_write_here(["read_write_float"]):
-            response = client.put("/read-write-float", json={"value": new})
-        assert client.get("/read-write-float").json()["value"] == new
+        with rest_controller_api.assert_write_here(["read_write_float"]):
+            response = test_client.put("/read-write-float", json={"value": new})
+        assert test_client.get("/read-write-float").json()["value"] == new
 
-    def test_read_bool(self, assertable_controller, client):
+    def test_read_bool(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
         expect = False
-        with assertable_controller.assert_read_here(["read_bool"]):
-            response = client.get("/read-bool")
+        with rest_controller_api.assert_read_here(["read_bool"]):
+            response = test_client.get("/read-bool")
         assert response.status_code == 200
         assert response.json()["value"] == expect
 
-    def test_write_bool(self, assertable_controller, client):
-        with assertable_controller.assert_write_here(["write_bool"]):
-            client.put("/write-bool", json={"value": True})
+    def test_write_bool(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
+        with rest_controller_api.assert_write_here(["write_bool"]):
+            test_client.put("/write-bool", json={"value": True})
 
-    def test_enum(self, assertable_controller, client):
-        enum_attr = assertable_controller.attributes["enum"]
+    def test_enum(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
+        enum_attr = rest_controller_api.attributes["enum"]
+        assert isinstance(enum_attr, AttrRW)
         enum_cls = enum_attr.datatype.dtype
         assert isinstance(enum_attr.get(), enum_cls)
         assert enum_attr.get() == enum_cls(0)
         expect = 0
-        with assertable_controller.assert_read_here(["enum"]):
-            response = client.get("/enum")
+        with rest_controller_api.assert_read_here(["enum"]):
+            response = test_client.get("/enum")
         assert response.status_code == 200
         assert response.json()["value"] == expect
         new = 2
-        with assertable_controller.assert_write_here(["enum"]):
-            response = client.put("/enum", json={"value": new})
-        assert client.get("/enum").json()["value"] == new
+        with rest_controller_api.assert_write_here(["enum"]):
+            response = test_client.put("/enum", json={"value": new})
+        assert test_client.get("/enum").json()["value"] == new
         assert isinstance(enum_attr.get(), enum_cls)
         assert enum_attr.get() == enum_cls(2)
 
-    def test_1d_waveform(self, assertable_controller, client):
-        attribute = assertable_controller.attributes["one_d_waveform"]
+    def test_1d_waveform(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
+        attribute = rest_controller_api.attributes["one_d_waveform"]
         expect = np.zeros((10,), dtype=np.int32)
+        assert isinstance(attribute, AttrRW)
         assert np.array_equal(attribute.get(), expect)
         assert isinstance(attribute.get(), np.ndarray)
 
-        with assertable_controller.assert_read_here(["one_d_waveform"]):
-            response = client.get("one-d-waveform")
+        with rest_controller_api.assert_read_here(["one_d_waveform"]):
+            response = test_client.get("one-d-waveform")
         assert np.array_equal(response.json()["value"], expect)
         new = [1, 2, 3]
-        with assertable_controller.assert_write_here(["one_d_waveform"]):
-            client.put("/one-d-waveform", json={"value": new})
-        assert np.array_equal(client.get("/one-d-waveform").json()["value"], new)
+        with rest_controller_api.assert_write_here(["one_d_waveform"]):
+            test_client.put("/one-d-waveform", json={"value": new})
+        assert np.array_equal(test_client.get("/one-d-waveform").json()["value"], new)
 
-        result = client.get("/one-d-waveform")
+        result = test_client.get("/one-d-waveform")
         assert np.array_equal(result.json()["value"], new)
         assert np.array_equal(attribute.get(), new)
         assert isinstance(attribute.get(), np.ndarray)
 
-    def test_2d_waveform(self, assertable_controller, client):
-        attribute = assertable_controller.attributes["two_d_waveform"]
+    def test_2d_waveform(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
+        attribute = rest_controller_api.attributes["two_d_waveform"]
+        assert isinstance(attribute, AttrRW)
         expect = np.zeros((10, 10), dtype=np.int32)
         assert np.array_equal(attribute.get(), expect)
         assert isinstance(attribute.get(), np.ndarray)
 
-        with assertable_controller.assert_read_here(["two_d_waveform"]):
-            result = client.get("/two-d-waveform")
+        with rest_controller_api.assert_read_here(["two_d_waveform"]):
+            result = test_client.get("/two-d-waveform")
         assert np.array_equal(result.json()["value"], expect)
         new = [[1, 2, 3], [4, 5, 6]]
-        with assertable_controller.assert_write_here(["two_d_waveform"]):
-            client.put("/two-d-waveform", json={"value": new})
+        with rest_controller_api.assert_write_here(["two_d_waveform"]):
+            test_client.put("/two-d-waveform", json={"value": new})
 
-        result = client.get("/two-d-waveform")
+        result = test_client.get("/two-d-waveform")
         assert np.array_equal(result.json()["value"], new)
         assert np.array_equal(attribute.get(), new)
         assert isinstance(attribute.get(), np.ndarray)
 
-    def test_go(self, assertable_controller, client):
-        with assertable_controller.assert_execute_here(["go"]):
-            response = client.put("/go")
-            assert response.status_code == 204
+    def test_go(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
+        with rest_controller_api.assert_execute_here(["go"]):
+            response = test_client.put("/go")
 
-    def test_read_child1(self, assertable_controller, client):
+        assert response.status_code == 204
+
+    def test_read_child1(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["SubController01", "read_int"]):
-            response = client.get("/SubController01/read-int")
+        with rest_controller_api.assert_read_here(["SubController01", "read_int"]):
+            response = test_client.get("/SubController01/read-int")
         assert response.status_code == 200
         assert response.json()["value"] == expect
 
-    def test_read_child2(self, assertable_controller, client):
+    def test_read_child2(
+        self, rest_controller_api: AssertableControllerAPI, test_client: TestClient
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["SubController02", "read_int"]):
-            response = client.get("/SubController02/read-int")
+        with rest_controller_api.assert_read_here(["SubController02", "read_int"]):
+            response = test_client.get("/SubController02/read-int")
         assert response.status_code == 200
         assert response.json()["value"] == expect

--- a/tests/transport/tango/test_dsr.py
+++ b/tests/transport/tango/test_dsr.py
@@ -1,14 +1,14 @@
 import asyncio
 import enum
-from unittest import mock
 
 import numpy as np
 import pytest
 from pytest_mock import MockerFixture
-from tango import DevState
+from tango import DeviceProxy, DevState
 from tango.test_context import DeviceTestContext
 from tests.assertable_controller import (
-    AssertableController,
+    AssertableControllerAPI,
+    MyTestController,
     TestHandler,
     TestSender,
     TestUpdater,
@@ -23,7 +23,16 @@ async def patch_run_threadsafe_blocking(coro, loop):
     await coro
 
 
-class TangoAssertableController(AssertableController):
+@pytest.fixture(scope="module")
+def mock_run_threadsafe_blocking(module_mocker: MockerFixture):
+    m = module_mocker.patch(
+        "fastcs.transport.tango.dsr._run_threadsafe_blocking",
+        patch_run_threadsafe_blocking,
+    )
+    yield m
+
+
+class TangoController(MyTestController):
     read_int = AttrR(Int(), handler=TestUpdater())
     read_write_int = AttrRW(Int(), handler=TestHandler())
     read_write_float = AttrRW(Float())
@@ -36,25 +45,32 @@ class TangoAssertableController(AssertableController):
 
 
 @pytest.fixture(scope="class")
-def assertable_controller(class_mocker: MockerFixture):
-    return TangoAssertableController(class_mocker)
+def tango_controller_api(class_mocker: MockerFixture) -> AssertableControllerAPI:
+    return AssertableControllerAPI(TangoController(), class_mocker)
+
+
+def create_test_context(tango_controller_api: AssertableControllerAPI):
+    device = TangoTransport(
+        tango_controller_api,
+        # This is passed to enable instantiating the transport, but tests must avoid
+        # using via patching of functions. It will raise NotImplementedError if used.
+        asyncio.AbstractEventLoop(),
+    )._dsr._device
+    # https://tango-controls.readthedocs.io/projects/pytango/en/v9.5.1/testing/test_context.html
+    with DeviceTestContext(device, debug=0) as proxy:
+        yield proxy
 
 
 class TestTangoDevice:
     @pytest.fixture(scope="class")
-    def tango_context(self, assertable_controller):
-        with mock.patch(
-            "fastcs.transport.tango.dsr._run_threadsafe_blocking",
-            patch_run_threadsafe_blocking,
-        ):
-            device = TangoTransport(
-                assertable_controller, asyncio.AbstractEventLoop()
-            )._dsr._device
-            # https://tango-controls.readthedocs.io/projects/pytango/en/v9.5.1/testing/test_context.html
-            with DeviceTestContext(device, debug=0) as proxy:
-                yield proxy
+    def tango_context(
+        self,
+        mock_run_threadsafe_blocking,
+        tango_controller_api: AssertableControllerAPI,
+    ):
+        yield from create_test_context(tango_controller_api)
 
-    def test_list_attributes(self, tango_context):
+    def test_list_attributes(self, tango_context: DeviceProxy):
         assert list(tango_context.get_attribute_list()) == [
             "Enum",
             "OneDWaveform",
@@ -86,90 +102,109 @@ class TestTangoDevice:
         expect = "The device is in ON state."
         assert tango_context.command_inout("Status") == expect
 
-    def test_read_int(self, assertable_controller, tango_context):
+    def test_read_int(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["read_int"]):
+        with tango_controller_api.assert_read_here(["read_int"]):
             result = tango_context.read_attribute("ReadInt").value
         assert result == expect
 
-    def test_read_write_int(self, assertable_controller, tango_context):
+    def test_read_write_int(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["read_write_int"]):
+        with tango_controller_api.assert_read_here(["read_write_int"]):
             result = tango_context.read_attribute("ReadWriteInt").value
         assert result == expect
         new = 9
-        with assertable_controller.assert_write_here(["read_write_int"]):
+        with tango_controller_api.assert_write_here(["read_write_int"]):
             tango_context.write_attribute("ReadWriteInt", new)
         assert tango_context.read_attribute("ReadWriteInt").value == new
 
-    def test_read_write_float(self, assertable_controller, tango_context):
+    def test_read_write_float(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
         expect = 0.0
-        with assertable_controller.assert_read_here(["read_write_float"]):
+        with tango_controller_api.assert_read_here(["read_write_float"]):
             result = tango_context.read_attribute("ReadWriteFloat").value
         assert result == expect
         new = 0.5
-        with assertable_controller.assert_write_here(["read_write_float"]):
+        with tango_controller_api.assert_write_here(["read_write_float"]):
             tango_context.write_attribute("ReadWriteFloat", new)
         assert tango_context.read_attribute("ReadWriteFloat").value == new
 
-    def test_read_bool(self, assertable_controller, tango_context):
+    def test_read_bool(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
         expect = False
-        with assertable_controller.assert_read_here(["read_bool"]):
+        with tango_controller_api.assert_read_here(["read_bool"]):
             result = tango_context.read_attribute("ReadBool").value
         assert result == expect
 
-    def test_write_bool(self, assertable_controller, tango_context):
-        with assertable_controller.assert_write_here(["write_bool"]):
+    def test_write_bool(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
+        with tango_controller_api.assert_write_here(["write_bool"]):
             tango_context.write_attribute("WriteBool", True)
 
-    def test_enum(self, assertable_controller, tango_context):
-        enum_attr = assertable_controller.attributes["enum"]
+    def test_enum(self, tango_controller_api: AssertableControllerAPI, tango_context):
+        enum_attr = tango_controller_api.attributes["enum"]
+        assert isinstance(enum_attr, AttrRW)
         enum_cls = enum_attr.datatype.dtype
         assert isinstance(enum_attr.get(), enum_cls)
         assert enum_attr.get() == enum_cls(0)
         expect = 0
-        with assertable_controller.assert_read_here(["enum"]):
+        with tango_controller_api.assert_read_here(["enum"]):
             result = tango_context.read_attribute("Enum").value
         assert result == expect
         new = 1
-        with assertable_controller.assert_write_here(["enum"]):
+        with tango_controller_api.assert_write_here(["enum"]):
             tango_context.write_attribute("Enum", new)
         assert tango_context.read_attribute("Enum").value == new
         assert isinstance(enum_attr.get(), enum_cls)
         assert enum_attr.get() == enum_cls(1)
 
-    def test_1d_waveform(self, assertable_controller, tango_context):
+    def test_1d_waveform(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
         expect = np.zeros((10,), dtype=np.int32)
-        with assertable_controller.assert_read_here(["one_d_waveform"]):
+        with tango_controller_api.assert_read_here(["one_d_waveform"]):
             result = tango_context.read_attribute("OneDWaveform").value
         assert np.array_equal(result, expect)
         new = np.array([1, 2, 3], dtype=np.int32)
-        with assertable_controller.assert_write_here(["one_d_waveform"]):
+        with tango_controller_api.assert_write_here(["one_d_waveform"]):
             tango_context.write_attribute("OneDWaveform", new)
         assert np.array_equal(tango_context.read_attribute("OneDWaveform").value, new)
 
-    def test_2d_waveform(self, assertable_controller, tango_context):
+    def test_2d_waveform(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
         expect = np.zeros((10, 10), dtype=np.int32)
-        with assertable_controller.assert_read_here(["two_d_waveform"]):
+        with tango_controller_api.assert_read_here(["two_d_waveform"]):
             result = tango_context.read_attribute("TwoDWaveform").value
         assert np.array_equal(result, expect)
         new = np.array([[1, 2, 3]], dtype=np.int32)
-        with assertable_controller.assert_write_here(["two_d_waveform"]):
+        with tango_controller_api.assert_write_here(["two_d_waveform"]):
             tango_context.write_attribute("TwoDWaveform", new)
         assert np.array_equal(tango_context.read_attribute("TwoDWaveform").value, new)
 
-    def test_go(self, assertable_controller, tango_context):
-        with assertable_controller.assert_execute_here(["go"]):
-            tango_context.command_inout("Go")
-
-    def test_read_child1(self, assertable_controller, tango_context):
+    def test_read_child1(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["SubController01", "read_int"]):
+        with tango_controller_api.assert_read_here(["SubController01", "read_int"]):
             result = tango_context.read_attribute("SubController01_ReadInt").value
         assert result == expect
 
-    def test_read_child2(self, assertable_controller, tango_context):
+    def test_read_child2(
+        self, tango_controller_api: AssertableControllerAPI, tango_context
+    ):
         expect = 0
-        with assertable_controller.assert_read_here(["SubController02", "read_int"]):
+        with tango_controller_api.assert_read_here(["SubController02", "read_int"]):
             result = tango_context.read_attribute("SubController02_ReadInt").value
         assert result == expect
+
+    def test_go(self, tango_controller_api: AssertableControllerAPI, tango_context):
+        with tango_controller_api.assert_execute_here(["go"]):
+            tango_context.command_inout("Go")


### PR DESCRIPTION
This changes a few key parts of the internal logic to make the static typing more robust and to improve the driver API. 

It is now possible to dynamically create `Method`s as well as `Attribute`s. This is shown in the new test [here](https://github.com/DiamondLightSource/FastCS/pull/87/files#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4R141) where a `Command` is added to a `Controller` during `initialise`.

The new `Command`, `Put` and `Scan` methods enable decoupling the `Controller` from the transport layer via a new `ControllerAPI` class, which replaces and extends the old `SingleMapping` class. The differences being:
- `ControllerAPI` doesn't need a reference to the `Controller` - it is entirely self contained because the methods are dynamically bound to the controller instance and can be called outside the context of the class.
- `ControllerAPI` maintains the tree structure from the `Controllers` where `SingleMapping`flattened it

Summary of changes:
- `Controller.get_controller_mappings` -> `ControllerAPI.walk_api`
- `SingleMapping.{attributes,command_methods,put_methods,scan_methods}` -> `ControllerAPI.{attributes,command_methods,put_methods,scan_methods}`
- `SingleMapping.Controller.path` -> `ControllerAPI.path`
- `{Command,Put,Scan}.fn` is now callable directly. Don't do `MethodType(method, controller)` or `getattr(controller, method.__name__)()`.
- `for Controller in SingleMapping.Controller.get_sub_controllers()` -> `for ControllerAPI in ControllerAPI.sub_apis()`

Fixes #74 
Fixes #60 
Fixes #93 
Fixes #62 