### PR TITLE
pass ioc options to `EpicsIOC.__init__` instead of `run`

### DIFF
--- a/src/fastcs/backends/epics/backend.py
+++ b/src/fastcs/backends/epics/backend.py
@@ -7,11 +7,16 @@ from .ioc import EpicsIOC, EpicsIOCOptions
 
 
 class EpicsBackend(Backend):
-    def __init__(self, controller: Controller, pv_prefix: str = "MY-DEVICE-PREFIX"):
+    def __init__(
+        self,
+        controller: Controller,
+        pv_prefix: str = "MY-DEVICE-PREFIX",
+        options: EpicsIOCOptions | None = None,
+    ):
         super().__init__(controller)
 
         self._pv_prefix = pv_prefix
-        self._ioc = EpicsIOC(pv_prefix, self._mapping)
+        self._ioc = EpicsIOC(pv_prefix, self._mapping, options=options)
 
     def create_docs(self, options: EpicsDocsOptions | None = None) -> None:
         EpicsDocs(self._mapping).create_docs(options)
@@ -19,5 +24,5 @@ class EpicsBackend(Backend):
     def create_gui(self, options: EpicsGUIOptions | None = None) -> None:
         EpicsGUI(self._mapping, self._pv_prefix).create_gui(options)
 
-    def _run(self, options: EpicsIOCOptions | None = None):
-        self._ioc.run(self._dispatcher, self._context, options)
+    def _run(self):
+        self._ioc.run(self._dispatcher, self._context)


### PR DESCRIPTION
Partially closes #76 