### PR TITLE
explicitly closed fastapi test client

### DIFF
--- a/tests/backends/rest/test_rest.py
+++ b/tests/backends/rest/test_rest.py
@@ -8,7 +8,8 @@ class TestRestServer:
     @pytest.fixture(scope="class")
     def client(self, assertable_controller):
         app = RestBackend(assertable_controller)._server._app
-        return TestClient(app)
+        with TestClient(app) as client:
+            yield client
 
     def test_read_int(self, assertable_controller, client):
         expect = 0


### PR DESCRIPTION
We'd get the following failure around 50% of test runs -
```
FAILED tests/backends/tango/test_dsr.py::TestTangoDevice::test_big_enum - pytest.PytestUnraisableExceptionWarning: Exception ignored in: <socket.socket fd=-1, family=1, type=1, proto=0>

Traceback (most recent call last):
  File "/dls_sw/apps/python/miniforge/4.10.0-0/envs/python3.11/lib/python3.11/unittest/mock.py", line 2124, in _mock_set_magics
    setattr(_type, entry, MagicProxy(entry, self))
                          ^^^^^^^^^^^^^^^^^^^^^^^
ResourceWarning: unclosed <socket.socket fd=28, family=1, type=1, proto=0>
```

This wasn't a problem in the big enum itself, commenting out `test_big_enum` will simply move the failure to the next test.

Explicitly closing the test client seems to do the trick.