### PR TITLE
Surpress tango test logging

### DIFF
--- a/tests/transport/tango/test_dsr.py
+++ b/tests/transport/tango/test_dsr.py
@@ -10,7 +10,7 @@ class TestTangoDevice:
     def tango_context(self, assertable_controller):
         # https://tango-controls.readthedocs.io/projects/pytango/en/v9.5.1/testing/test_context.html
         device = TangoTransport(assertable_controller)._dsr._device
-        with DeviceTestContext(device) as proxy:
+        with DeviceTestContext(device, debug=0) as proxy:
             yield proxy
 
     def test_list_attributes(self, tango_context):


### PR DESCRIPTION
fixes #83 
Suppress the log messages dumped at the end of testing:
```
...
==================================================================== 53 passed in 5.11s =====================================================================
2024-11-28T14:50:44,795737+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: ReadInt
2024-11-28T14:50:44,799603+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: ReadWriteInt
2024-11-28T14:50:44,802900+0000 INFO (dsr.py:44) test/nodb/assertablecontroller called fset method: ReadWriteInt
2024-11-28T14:50:44,804099+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: ReadWriteInt
2024-11-28T14:50:44,809197+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: ReadWriteFloat
2024-11-28T14:50:44,811936+0000 INFO (dsr.py:44) test/nodb/assertablecontroller called fset method: ReadWriteFloat
2024-11-28T14:50:44,812998+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: ReadWriteFloat
2024-11-28T14:50:44,817963+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: ReadBool
2024-11-28T14:50:44,822940+0000 INFO (dsr.py:44) test/nodb/assertablecontroller called fset method: WriteBool
2024-11-28T14:50:44,827061+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: StringEnum
2024-11-28T14:50:44,830157+0000 INFO (dsr.py:44) test/nodb/assertablecontroller called fset method: StringEnum
2024-11-28T14:50:44,831114+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: StringEnum
2024-11-28T14:50:44,835263+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: BigEnum
2024-11-28T14:50:44,841047+0000 INFO (dsr.py:101) test/nodb/assertablecontroller called  f method: Go
2024-11-28T14:50:44,845192+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: ReadInt
2024-11-28T14:50:44,849192+0000 INFO (dsr.py:26) test/nodb/assertablecontroller called fget method: ReadInt
docs installed: accessible-pygments==0.0.5,aioca==1.8.1,aioserial==1.3.1,alabaster==1.0.0,annotated-types==0.7.0,anyio==4.6.2.post1,babel==2.16.0,beautifulso
...
```