### PR TITLE
Add optional version command to launcher

### DIFF
--- a/src/fastcs/launch.py
+++ b/src/fastcs/launch.py
@@ -77,7 +77,9 @@ def launch(
 
     Args:
         controller_class (type[Controller]): The FastCS Controller to instantiate.
-        It must have a type-hinted __init__ method and no more than 2 arguments.
+            It must have a type-hinted __init__ method and no more than 2 arguments.
+        version (Optional[str]): The version of the FastCS Controller.
+            Optional
 
     Raises:
         LaunchError: If the class's __init__ is not as expected

--- a/src/fastcs/launch.py
+++ b/src/fastcs/launch.py
@@ -62,7 +62,10 @@ class FastCS:
         self._transport.run()
 
 
-def launch(controller_class: type[Controller]) -> None:
+def launch(
+    controller_class: type[Controller],
+    version: str | None = None,
+) -> None:
     """
     Serves as an entry point for starting FastCS applications.
 
@@ -86,10 +89,13 @@ def launch(controller_class: type[Controller]) -> None:
         if __name__ == "__main__":
             launch(MyController)
     """
-    _launch(controller_class)()
+    _launch(controller_class, version)()
 
 
-def _launch(controller_class: type[Controller]) -> typer.Typer:
+def _launch(
+    controller_class: type[Controller],
+    version: str | None = None,
+) -> typer.Typer:
     fastcs_options = _extract_options_model(controller_class)
     launch_typer = typer.Typer()
 
@@ -145,6 +151,14 @@ def _launch(controller_class: type[Controller]) -> typer.Typer:
         if "docs" in options_yaml["transport"]:
             instance.create_docs()
         instance.run()
+
+    if version:
+
+        @launch_typer.command(
+            name="version", help=f"{controller_class.__name__} version"
+        )
+        def version_command():
+            print(version)
 
     return launch_typer
 

--- a/src/fastcs/launch.py
+++ b/src/fastcs/launch.py
@@ -7,6 +7,8 @@ import typer
 from pydantic import BaseModel, create_model
 from ruamel.yaml import YAML
 
+from fastcs.__main__ import __version__
+
 from .backend import Backend
 from .controller import Controller
 from .exceptions import LaunchError
@@ -152,13 +154,11 @@ def _launch(
             instance.create_docs()
         instance.run()
 
-    if version:
-
-        @launch_typer.command(
-            name="version", help=f"{controller_class.__name__} version"
-        )
-        def version_command():
-            print(version)
+    @launch_typer.command(name="version", help=f"{controller_class.__name__} version")
+    def version_command():
+        if version:
+            print(f"{controller_class.__name__}: {version}")
+        print(f"FastCS: {__version__}")
 
     return launch_typer
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -99,6 +99,14 @@ def test_over_defined_schema():
     assert str(exc_info.value) == error
 
 
+def test_version():
+    expected = "0.0.1"
+    app = _launch(SingleArg, version=expected)
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == expected
+
+
 def test_launch_minimal(mocker: MockerFixture, data):
     run = mocker.patch("fastcs.launch.FastCS.run")
     gui = mocker.patch("fastcs.launch.FastCS.create_gui")

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -6,6 +6,7 @@ from pydantic import create_model
 from pytest_mock import MockerFixture
 from typer.testing import CliRunner
 
+from fastcs.__main__ import __version__
 from fastcs.controller import Controller
 from fastcs.exceptions import LaunchError
 from fastcs.launch import TransportOptions, _launch, launch
@@ -100,11 +101,20 @@ def test_over_defined_schema():
 
 
 def test_version():
-    expected = "0.0.1"
-    app = _launch(SingleArg, version=expected)
+    impl_version = "0.0.1"
+    expected = f"SingleArg: {impl_version}\n" f"FastCS: {__version__}\n"
+    app = _launch(SingleArg, version=impl_version)
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
-    assert result.stdout.strip() == expected
+    assert result.stdout == expected
+
+
+def test_no_version():
+    expected = f"FastCS: {__version__}\n"
+    app = _launch(SingleArg)
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert result.stdout == expected
 
 
 def test_launch_minimal(mocker: MockerFixture, data):


### PR DESCRIPTION
`version` is a useful cli command - this option adds the command if the developer passes a version that should be output when executing `${my_fastcs_device} version`