### PR TITLE
Changed from `builder.aOut` to `builder.Action` for commands

### DIFF
--- a/src/fastcs/transport/epics/ioc.py
+++ b/src/fastcs/transport/epics/ioc.py
@@ -355,10 +355,8 @@ def _create_and_link_command_pv(
     async def wrapped_method(_: Any):
         await method()
 
-    record = builder.aOut(
+    record = builder.Action(
         f"{pv_prefix}:{pv_name}",
-        initial_value=0,
-        always_update=True,
         on_update=wrapped_method,
     )
 

--- a/tests/transport/epics/test_ioc.py
+++ b/tests/transport/epics/test_ioc.py
@@ -269,9 +269,7 @@ def test_ioc(mocker: MockerFixture, controller: Controller):
         always_update=True,
         on_update=mocker.ANY,
     )
-    builder.aOut.assert_any_call(
-        f"{DEVICE}:Go", initial_value=0, always_update=True, on_update=mocker.ANY
-    )
+    builder.Action.assert_any_call(f"{DEVICE}:Go", on_update=mocker.ANY)
 
     # Check info tags are added
     add_pvi_info.assert_called_once_with(f"{DEVICE}:PVI")
@@ -443,10 +441,8 @@ def test_long_pv_names_discarded(mocker: MockerFixture):
     assert not getattr(long_name_controller, long_command_name).fastcs_method.enabled
 
     short_command_pv_name = "command_short_name".title().replace("_", "")
-    builder.aOut.assert_called_once_with(
+    builder.Action.assert_called_once_with(
         f"{DEVICE}:{short_command_pv_name}",
-        initial_value=0,
-        always_update=True,
         on_update=mocker.ANY,
     )
     with pytest.raises(AssertionError):


### PR DESCRIPTION
Closes #99

`builder.Action` is a wrapper to a `boolOut` with `always_update=True`. This is how PandaBlocks-ioc does it and will probably work with ophyd-async.

@dperl-dls can you please test this branch? (or if it's too much of a pain with updating alongside other changes then copy [the line](https://github.com/DiamondLightSource/FastCS/blob/5708b391d2a081fa1d8fdba6ae640ad871b00ea1/src/fastcs/transport/epics/ioc.py#L358-L361) where I do `aOut -> Action` locally.