### PR TITLE
Add SimpleHandler to make minimal Attributes functional

### DIFF
--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -1,8 +1,9 @@
 from functools import partial
 
 import pytest
+from pytest_mock import MockerFixture
 
-from fastcs.attributes import AttrR, AttrRW
+from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.datatypes import Int, String
 
 
@@ -31,3 +32,28 @@ async def test_attributes():
     await attr_rw.process(2)
     assert device["number"] == 2
     assert ui["number"] == 2
+
+
+@pytest.mark.asyncio
+async def test_simple_handler_w(mocker: MockerFixture):
+    attr = AttrW(Int())
+    update_display_mock = mocker.patch.object(attr, "update_display_without_process")
+
+    # This is called by the transport when it receives a put
+    await attr.sender.put(mocker.ANY, attr, 1)
+
+    # The callback to update the transport display should be called
+    update_display_mock.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_simple_handler_rw(mocker: MockerFixture):
+    attr = AttrRW(Int())
+    update_display_mock = mocker.patch.object(attr, "update_display_without_process")
+    set_mock = mocker.patch.object(attr, "set")
+
+    await attr.sender.put(mocker.ANY, attr, 1)
+
+    update_display_mock.assert_called_once_with(1)
+    # The Sender of the attribute should just set the value on the attribute
+    set_mock.assert_awaited_once_with(1)


### PR DESCRIPTION
This allows creating Attributes without a Handler for parameters that are only used for internal controller logic and not sent directly to a device.

Fixes #101 