### PR TITLE
Fix for default file paths

### DIFF
--- a/src/fastcs/transport/epics/gui.py
+++ b/src/fastcs/transport/epics/gui.py
@@ -122,7 +122,7 @@ class EpicsGUI:
         device = Device(label=options.title, children=components)
 
         formatter = DLSFormatter()
-        formatter.format(device, options.output_path)
+        formatter.format(device, options.output_path.resolve())
 
     def extract_mapping_components(self, mapping: SingleMapping) -> Tree:
         components: Tree = []

--- a/src/fastcs/transport/epics/options.py
+++ b/src/fastcs/transport/epics/options.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 @dataclass
 class EpicsDocsOptions:
-    path: Path = Path.cwd()
+    path: Path = Path(".")
     depth: int | None = None
 
 
@@ -16,7 +16,7 @@ class EpicsGUIFormat(Enum):
 
 @dataclass
 class EpicsGUIOptions:
-    output_path: Path = Path.cwd() / "output.bob"
+    output_path: Path = Path(".") / "output.bob"
     file_format: EpicsGUIFormat = EpicsGUIFormat.bob
     title: str = "Simple Device"
 


### PR DESCRIPTION
Currently the default epics options set an absolute file path. For example:
```
@dataclass
class EpicsDocsOptions:
    path: Path = Path.cwd()  # The subject of this PR
    depth: int | None = None
```
This means that the resulting schema depends on the host and execution context:
```
    "EpicsDocsOptions": {
      "properties": {
        "path": {
          "default": "/workspaces/thorlabs-mff-fastcs",  # Changes dynamically
          "format": "path",
          "title": "Path",
          "type": "string"
        },
        "depth": {
          "anyOf": [
            {
              "type": "integer"
            },
            {
              "type": "null"
            }
          ],
          "default": null,
          "title": "Depth"
        }
      },
```
Here it is proposed to rather use a relative path. This does not prevent an absolute path being passed. It allows the same functionality as before but with a consistent schema and additionally allows to make alterations to the relative path. This results in a schema of: 
```
    "EpicsDocsOptions": {
      "properties": {
        "path": {
          "default": ".",
          "format": "path",
          "title": "Path",
          "type": "string"
        },
        "depth": {
          "anyOf": [
            {
              "type": "integer"
            },
            {
              "type": "null"
            }
          ],
          "default": null,
          "title": "Depth"
        }
      },
```