### PR TITLE
Add get_controller_schema function

### DIFF
--- a/src/fastcs/launch.py
+++ b/src/fastcs/launch.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import json
 from pathlib import Path
-from typing import Annotated, Optional, TypeAlias, get_type_hints
+from typing import Annotated, Any, Optional, TypeAlias, get_type_hints
 
 import typer
 from pydantic import BaseModel, create_model
@@ -231,3 +231,9 @@ def _extract_options_model(controller_class: type[Controller]) -> type[BaseModel
             f".__init__' but received {len(args)} as `{sig}`"
         )
     return fastcs_options
+
+
+def get_controller_schema(target: type[Controller]) -> dict[str, Any]:
+    options_model = _extract_options_model(target)
+    target_schema = options_model.model_json_schema()
+    return target_schema

--- a/tests/data/schema.json
+++ b/tests/data/schema.json
@@ -3,7 +3,7 @@
     "EpicsDocsOptions": {
       "properties": {
         "path": {
-          "default": "/home/esq51579/WIP/FastCS",
+          "default": ".",
           "format": "path",
           "title": "Path",
           "type": "string"
@@ -35,7 +35,7 @@
     "EpicsGUIOptions": {
       "properties": {
         "output_path": {
-          "default": "/home/esq51579/WIP/FastCS/output.bob",
+          "default": "output.bob",
           "format": "path",
           "title": "Output Path",
           "type": "string"

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import pytest
 from pydantic import create_model
 from pytest_mock import MockerFixture
+from ruamel.yaml import YAML
 from typer.testing import CliRunner
 
 from fastcs.__main__ import __version__
@@ -11,7 +12,7 @@ from fastcs.attributes import AttrR
 from fastcs.controller import Controller
 from fastcs.datatypes import Int
 from fastcs.exceptions import LaunchError
-from fastcs.launch import TransportOptions, _launch, launch
+from fastcs.launch import TransportOptions, _launch, get_controller_schema, launch
 
 
 @dataclass
@@ -133,3 +134,9 @@ def test_launch(mocker: MockerFixture, data):
     run.assert_called_once()
     gui.assert_called_once()
     docs.assert_called_once()
+
+
+def test_get_schema(data):
+    ref_schema = YAML(typ="safe").load(data / "schema.json")
+    target_schema = get_controller_schema(IsHinted)
+    assert target_schema == ref_schema


### PR DESCRIPTION
This adds a `get_controller_schema` function that can be convenient for assessing the schema of a controller - useful for the testing of a FastCS project. Another benefit is that the `tests/data/schema.json` is now also assessed by the new test - so the test will fail if its not kept up to date