### PR TITLE
fix: Allowed multiple update callbacks on an `AttrR`

### DIFF
--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -65,7 +65,7 @@ def _link_put_tasks(controller_api: ControllerAPI) -> None:
         attribute = controller_api.attributes[name]
         match attribute:
             case AttrW():
-                attribute.set_process_callback(method.fn)
+                attribute.add_process_callback(method.fn)
             case _:
                 raise FastCSException(
                     f"Mode {attribute.access_mode} does not "
@@ -84,7 +84,7 @@ def _link_attribute_sender_class(
                 )
 
                 callback = _create_sender_callback(attribute, controller)
-                attribute.set_process_callback(callback)
+                attribute.add_process_callback(callback)
 
 
 def _create_sender_callback(attribute, controller):

--- a/src/fastcs/transport/epics/ca/ioc.py
+++ b/src/fastcs/transport/epics/ca/ioc.py
@@ -159,7 +159,7 @@ def _create_and_link_read_pv(
     record = _make_record(f"{pv_prefix}:{pv_name}", attribute)
     _add_attr_pvi_info(record, pv_prefix, attr_name, "r")
 
-    attribute.set_update_callback(async_record_set)
+    attribute.add_update_callback(async_record_set)
 
 
 def _make_record(
@@ -200,7 +200,7 @@ def _create_and_link_write_pv(
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "w")
 
-    attribute.set_write_display_callback(async_write_display)
+    attribute.add_write_display_callback(async_write_display)
 
 
 def _create_and_link_command_pvs(

--- a/src/fastcs/transport/epics/pva/_pv_handlers.py
+++ b/src/fastcs/transport/epics/pva/_pv_handlers.py
@@ -114,12 +114,11 @@ def make_shared_pv(attribute: Attribute) -> SharedPV:
     shared_pv = SharedPV(**kwargs)
 
     if isinstance(attribute, AttrR):
-        shared_pv.post(cast_to_p4p_value(attribute, attribute.get()))
 
         async def on_update(value):
             shared_pv.post(cast_to_p4p_value(attribute, value))
 
-        attribute.set_update_callback(on_update)
+        attribute.add_update_callback(on_update)
 
     return shared_pv
 

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -23,13 +23,13 @@ async def test_attributes():
         device["number"] += 1
 
     attr_r = AttrR(String())
-    attr_r.set_update_callback(partial(update_ui, key="state"))
+    attr_r.add_update_callback(partial(update_ui, key="state"))
     await attr_r.set(device["state"])
     assert ui["state"] == "Idle"
 
     attr_rw = AttrRW(Int())
-    attr_rw.set_process_callback(partial(send, key="number"))
-    attr_rw.set_write_display_callback(partial(update_ui, key="number"))
+    attr_rw.add_process_callback(partial(send, key="number"))
+    attr_rw.add_write_display_callback(partial(update_ui, key="number"))
     await attr_rw.process(2)
     assert device["number"] == 2
     assert ui["number"] == 2

--- a/tests/transport/epics/ca/test_softioc.py
+++ b/tests/transport/epics/ca/test_softioc.py
@@ -58,7 +58,7 @@ async def test_create_and_link_read_pv(mocker: MockerFixture):
     record = make_record.return_value
 
     attribute = AttrR(Int())
-    attribute.set_update_callback = mocker.MagicMock()
+    attribute.add_update_callback = mocker.MagicMock()
 
     _create_and_link_read_pv("PREFIX", "PV", "attr", attribute)
 
@@ -66,8 +66,8 @@ async def test_create_and_link_read_pv(mocker: MockerFixture):
     add_attr_pvi_info.assert_called_once_with(record, "PREFIX", "attr", "r")
 
     # Extract the callback generated and set in the function and call it
-    attribute.set_update_callback.assert_called_once_with(mocker.ANY)
-    record_set_callback = attribute.set_update_callback.call_args[0][0]
+    attribute.add_update_callback.assert_called_once_with(mocker.ANY)
+    record_set_callback = attribute.add_update_callback.call_args[0][0]
     await record_set_callback(1)
 
     record.set.assert_called_once_with(1)
@@ -123,7 +123,7 @@ async def test_create_and_link_write_pv(mocker: MockerFixture):
 
     attribute = AttrW(Int())
     attribute.process_without_display_update = mocker.AsyncMock()
-    attribute.set_write_display_callback = mocker.MagicMock()
+    attribute.add_write_display_callback = mocker.MagicMock()
 
     _create_and_link_write_pv("PREFIX", "PV", "attr", attribute)
 
@@ -131,8 +131,8 @@ async def test_create_and_link_write_pv(mocker: MockerFixture):
     add_attr_pvi_info.assert_called_once_with(record, "PREFIX", "attr", "w")
 
     # Extract the write update callback generated and set in the function and call it
-    attribute.set_write_display_callback.assert_called_once_with(mocker.ANY)
-    write_display_callback = attribute.set_write_display_callback.call_args[0][0]
+    attribute.add_write_display_callback.assert_called_once_with(mocker.ANY)
+    write_display_callback = attribute.add_write_display_callback.call_args[0][0]
     await write_display_callback(1)
 
     record.set.assert_called_once_with(1, process=False)


### PR DESCRIPTION
* Transports will add an update callback, so if we don't allow for multiple then running them simultaneously won't work.
* The controller level can add their own now too.