### PR TITLE
Ensure backend creates sender callbacks with the correct controller

### DIFF
--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -30,7 +30,10 @@ class Backend:
     def _link_process_tasks(self):
         for controller_api in self.controller_api.walk_api():
             _link_put_tasks(controller_api)
-            _link_attribute_sender_class(controller_api, self._controller)
+            _link_attribute_sender_class(
+                controller_api,
+                self._controller.get_controller_by_path(controller_api.path),
+            )
 
     def __del__(self):
         self._stop_scan_tasks()
@@ -74,7 +77,7 @@ def _link_put_tasks(controller_api: ControllerAPI) -> None:
 
 
 def _link_attribute_sender_class(
-    controller_api: ControllerAPI, controller: Controller
+    controller_api: ControllerAPI, controller: BaseController
 ) -> None:
     for attr_name, attribute in controller_api.attributes.items():
         match attribute:

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -4,6 +4,7 @@ from copy import copy
 from typing import get_type_hints
 
 from fastcs.attributes import Attribute
+from fastcs.exceptions import FastCSException
 
 
 class BaseController:
@@ -100,6 +101,19 @@ class BaseController:
 
     def get_sub_controllers(self) -> dict[str, SubController]:
         return self.__sub_controller_tree
+
+    def __getitem__(self, key: str) -> SubController:
+        if key not in self.__sub_controller_tree:
+            raise FastCSException(f"Controller {self} has no sub controller '{key}'")
+
+        return self.__sub_controller_tree[key]
+
+    def get_controller_by_path(self, path: list[str]) -> BaseController:
+        if path:
+            sub_controller, remaining_path = self[path[0]], path[1:]
+            return sub_controller.get_controller_by_path(remaining_path)
+
+        return self
 
 
 class Controller(BaseController):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,6 +3,7 @@ import pytest
 from fastcs.attributes import AttrR
 from fastcs.controller import Controller, SubController
 from fastcs.datatypes import Int
+from fastcs.exceptions import FastCSException
 
 
 def test_controller_nesting():
@@ -16,7 +17,9 @@ def test_controller_nesting():
     assert sub_controller.path == ["a"]
     assert sub_sub_controller.path == ["a", "b"]
     assert controller.get_sub_controllers() == {"a": sub_controller}
+    assert controller["a"] == sub_controller
     assert sub_controller.get_sub_controllers() == {"b": sub_sub_controller}
+    assert controller["a"]["b"] == sub_sub_controller
 
     with pytest.raises(
         ValueError, match=r"Controller .* already has a SubController registered as .*"
@@ -112,3 +115,12 @@ def test_root_attribute():
         ),
     ):
         FailingController(SomeSubController())
+
+
+def test_controller_getitem(controller):
+    assert controller["SubController01"] == controller.get_sub_controllers().get(
+        "SubController01"
+    )
+
+    with pytest.raises(FastCSException, match=r"Controller .* has no sub controller.*"):
+        controller["DoesNotExist"]


### PR DESCRIPTION
Fixes #130

This is not the ideal fix, but tried many different things and they were all quite horrible:

- Adding the controller back into `ControllerAPI` - the transport should not have access to it
- Adding the `ScanCallback`s to `ControllerAPI` - this just doesn't really make sense, only the Backend needs them
- Make the `Backend` manually parse methods and attribute out of the `Controller` and only create the `ControllerAPI` at the end - this was OK, but meant repeating [this](https://github.com/DiamondLightSource/FastCS/blob/main/src/fastcs/backend.py#L171-L184) code multiple times.

 I think the interface of the handlers may not be correct, which is making this painful. It doesn't seem necessary for the whole controller to be passed into the handler put/update methods.

I don't know why that tango test is suddenly failing on 3.12 :cry: It doesn't happen on main or locally.