### PR TITLE
Add Handler.initialise(controller)

### DIFF
--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -22,16 +22,20 @@ class AttrMode(Enum):
 class Sender(Protocol):
     """Protocol for setting the value of an ``Attribute``."""
 
-<<<<<<< HEAD
-    async def put(
-        self, controller: fastcs.controller.BaseController, attr: AttrW, value: Any
-    ) -> None:
-=======
-    async def initialise(self, controller: Any):
+    # Record the controller that owns this attribute handler
+    controller: Any = None
+
+    async def initialise(self, controller: Any) -> None:
+        # Register the controller
+        self.controller = controller
+
+        # Continue with initialisation
+        await self._initialise()
+
+    async def _initialise(self) -> None:
         pass
 
-    async def put(self, controller: Any, attr: AttrW, value: Any) -> None:
->>>>>>> 43721ff (Added default initialise methods to Sender and Updater base classes. Added initialise method to Attribute, checks for handler and calls the method. Moved initialise into BaseController class, loops over attributes calling initialise with a reference to self. Added unit test for Attribute class.)
+    async def put(self, attr: AttrW, value: Any) -> None:
         pass
 
 
@@ -39,19 +43,25 @@ class Sender(Protocol):
 class Updater(Protocol):
     """Protocol for updating the cached readback value of an ``Attribute``."""
 
+    # Record the controller that owns this attribute handler
+    controller: Any = None
+
     # If update period is None then the attribute will not be updated as a task.
     update_period: float | None = None
 
-<<<<<<< HEAD
-    async def update(
-        self, controller: fastcs.controller.BaseController, attr: AttrR
-    ) -> None:
-=======
-    async def initialise(self, controller: Any):
+    async def initialise(self, controller: Any) -> None:
         pass
 
-    async def update(self, controller: Any, attr: AttrR) -> None:
->>>>>>> 43721ff (Added default initialise methods to Sender and Updater base classes. Added initialise method to Attribute, checks for handler and calls the method. Moved initialise into BaseController class, loops over attributes calling initialise with a reference to self. Added unit test for Attribute class.)
+        # Register the controller
+        self.controller = controller
+
+        # Continue with initialisation
+        await self._initialise()
+
+    async def _initialise(self) -> None:
+        pass
+
+    async def update(self, attr: AttrR) -> None:
         pass
 
 
@@ -65,15 +75,13 @@ class Handler(Sender, Updater, Protocol):
 class SimpleHandler(Handler):
     """Handler for internal parameters"""
 
-    async def put(
-        self, controller: fastcs.controller.BaseController, attr: AttrW, value: Any
-    ):
+    async def put(self, attr: AttrW, value: Any):
         await attr.update_display_without_process(value)
 
         if isinstance(attr, AttrRW):
             await attr.set(value)
 
-    async def update(self, controller: Any, attr: AttrR):
+    async def update(self, attr: AttrR):
         raise RuntimeError("SimpleHandler cannot update")
 
 

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -22,9 +22,11 @@ class AttrMode(Enum):
 class Sender(Protocol):
     """Protocol for setting the value of an ``Attribute``."""
 
-    async def initialise(self, controller: Any) -> None: ...
+    async def initialise(self, controller: fastcs.controller.BaseController) -> None:
+        pass
 
-    async def put(self, attr: AttrW[T], value: T) -> None: ...
+    async def put(self, attr: AttrW[T], value: T) -> None:
+        pass
 
 
 @runtime_checkable
@@ -34,9 +36,11 @@ class Updater(Protocol):
     # If update period is None then the attribute will not be updated as a task.
     update_period: float | None = None
 
-    async def initialise(self, controller: Any) -> None: ...
+    async def initialise(self, controller: fastcs.controller.BaseController) -> None:
+        pass
 
-    async def update(self, attr: AttrR) -> None: ...
+    async def update(self, attr: AttrR) -> None:
+        pass
 
 
 @runtime_checkable
@@ -48,9 +52,6 @@ class Handler(Sender, Updater, Protocol):
 
 class SimpleHandler(Handler):
     """Handler for internal parameters"""
-
-    async def initialise(self, controller: Any) -> None:
-        pass
 
     async def put(self, attr: AttrW[T], value: T) -> None:
         await attr.update_display_without_process(value)
@@ -107,7 +108,7 @@ class Attribute(Generic[T]):
     def group(self) -> str | None:
         return self._group
 
-    async def initialise(self, controller: Any) -> None:
+    async def initialise(self, controller: fastcs.controller.BaseController) -> None:
         if self._handler is not None:
             await self._handler.initialise(controller)
 

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -36,7 +36,7 @@ class AttrHandlerR(_BaseAttrHandler):
     # If update period is None then the attribute will not be updated as a task.
     update_period: float | None = None
 
-    async def update(self, attr: AttrR) -> None:
+    async def update(self, attr: AttrR[T]) -> None:
         pass
 
 

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -18,19 +18,19 @@ class AttrMode(Enum):
     READ_WRITE = 3
 
 
-class _BaseHandler:
+class _BaseAttrHandler:
     async def initialise(self, controller: fastcs.controller.BaseController) -> None:
         pass
 
 
-class Setter(_BaseHandler):
+class AttrHandlerW(_BaseAttrHandler):
     """Protocol for setting the value of an ``Attribute``."""
 
     async def put(self, attr: AttrW[T], value: T) -> None:
         pass
 
 
-class Updater(_BaseHandler):
+class AttrHandlerR(_BaseAttrHandler):
     """Protocol for updating the cached readback value of an ``Attribute``."""
 
     # If update period is None then the attribute will not be updated as a task.
@@ -40,13 +40,13 @@ class Updater(_BaseHandler):
         pass
 
 
-class Handler(Setter, Updater):
-    """Protocol encapsulating both ``Setter`` and ``Updater``."""
+class AttrHandlerRW(AttrHandlerR, AttrHandlerW):
+    """Protocol encapsulating both ``AttrHandlerR`` and ``AttHandlerW``."""
 
     pass
 
 
-class SimpleHandler(Handler):
+class SimpleAttrHandler(AttrHandlerRW):
     """Handler for internal parameters"""
 
     async def put(self, attr: AttrW[T], value: T) -> None:
@@ -131,7 +131,7 @@ class AttrR(Attribute[T]):
         datatype: DataType[T],
         access_mode=AttrMode.READ,
         group: str | None = None,
-        handler: Updater | None = None,
+        handler: AttrHandlerR | None = None,
         initial_value: T | None = None,
         description: str | None = None,
     ) -> None:
@@ -163,7 +163,7 @@ class AttrR(Attribute[T]):
         self._update_callbacks.append(callback)
 
     @property
-    def updater(self) -> Updater | None:
+    def updater(self) -> AttrHandlerR | None:
         return self._updater
 
 
@@ -175,7 +175,7 @@ class AttrW(Attribute[T]):
         datatype: DataType[T],
         access_mode=AttrMode.WRITE,
         group: str | None = None,
-        handler: Setter | None = None,
+        handler: AttrHandlerW | None = None,
         description: str | None = None,
     ) -> None:
         super().__init__(
@@ -191,7 +191,7 @@ class AttrW(Attribute[T]):
         if handler is not None:
             self._setter = handler
         else:
-            self._setter = SimpleHandler()
+            self._setter = SimpleAttrHandler()
 
     async def process(self, value: T) -> None:
         await self.process_without_display_update(value)
@@ -221,7 +221,7 @@ class AttrW(Attribute[T]):
         self._write_display_callbacks.append(callback)
 
     @property
-    def sender(self) -> Setter:
+    def sender(self) -> AttrHandlerW:
         return self._setter
 
 
@@ -233,7 +233,7 @@ class AttrRW(AttrR[T], AttrW[T]):
         datatype: DataType[T],
         access_mode=AttrMode.READ_WRITE,
         group: str | None = None,
-        handler: Handler | None = None,
+        handler: AttrHandlerRW | None = None,
         initial_value: T | None = None,
         description: str | None = None,
     ) -> None:

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -22,9 +22,16 @@ class AttrMode(Enum):
 class Sender(Protocol):
     """Protocol for setting the value of an ``Attribute``."""
 
+<<<<<<< HEAD
     async def put(
         self, controller: fastcs.controller.BaseController, attr: AttrW, value: Any
     ) -> None:
+=======
+    async def initialise(self, controller: Any):
+        pass
+
+    async def put(self, controller: Any, attr: AttrW, value: Any) -> None:
+>>>>>>> 43721ff (Added default initialise methods to Sender and Updater base classes. Added initialise method to Attribute, checks for handler and calls the method. Moved initialise into BaseController class, loops over attributes calling initialise with a reference to self. Added unit test for Attribute class.)
         pass
 
 
@@ -35,9 +42,16 @@ class Updater(Protocol):
     # If update period is None then the attribute will not be updated as a task.
     update_period: float | None = None
 
+<<<<<<< HEAD
     async def update(
         self, controller: fastcs.controller.BaseController, attr: AttrR
     ) -> None:
+=======
+    async def initialise(self, controller: Any):
+        pass
+
+    async def update(self, controller: Any, attr: AttrR) -> None:
+>>>>>>> 43721ff (Added default initialise methods to Sender and Updater base classes. Added initialise method to Attribute, checks for handler and calls the method. Moved initialise into BaseController class, loops over attributes calling initialise with a reference to self. Added unit test for Attribute class.)
         pass
 
 
@@ -84,6 +98,7 @@ class Attribute(Generic[T]):
         self._datatype: DataType[T] = datatype
         self._access_mode: AttrMode = access_mode
         self._group = group
+        self._handler = handler
         self.enabled = True
         self.description = description
 
@@ -106,6 +121,10 @@ class Attribute(Generic[T]):
     @property
     def group(self) -> str | None:
         return self._group
+
+    async def initialise(self, controller: Any) -> None:
+        if self._handler is not None:
+            await self._handler.initialise(controller)
 
     def add_update_datatype_callback(
         self, callback: Callable[[DataType[T]], None]

--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -22,47 +22,21 @@ class AttrMode(Enum):
 class Sender(Protocol):
     """Protocol for setting the value of an ``Attribute``."""
 
-    # Record the controller that owns this attribute handler
-    controller: Any = None
+    async def initialise(self, controller: Any) -> None: ...
 
-    async def initialise(self, controller: Any) -> None:
-        # Register the controller
-        self.controller = controller
-
-        # Continue with initialisation
-        await self._initialise()
-
-    async def _initialise(self) -> None:
-        pass
-
-    async def put(self, attr: AttrW, value: Any) -> None:
-        pass
+    async def put(self, attr: AttrW[T], value: T) -> None: ...
 
 
 @runtime_checkable
 class Updater(Protocol):
     """Protocol for updating the cached readback value of an ``Attribute``."""
 
-    # Record the controller that owns this attribute handler
-    controller: Any = None
-
     # If update period is None then the attribute will not be updated as a task.
     update_period: float | None = None
 
-    async def initialise(self, controller: Any) -> None:
-        pass
+    async def initialise(self, controller: Any) -> None: ...
 
-        # Register the controller
-        self.controller = controller
-
-        # Continue with initialisation
-        await self._initialise()
-
-    async def _initialise(self) -> None:
-        pass
-
-    async def update(self, attr: AttrR) -> None:
-        pass
+    async def update(self, attr: AttrR) -> None: ...
 
 
 @runtime_checkable
@@ -75,13 +49,16 @@ class Handler(Sender, Updater, Protocol):
 class SimpleHandler(Handler):
     """Handler for internal parameters"""
 
-    async def put(self, attr: AttrW, value: Any):
+    async def initialise(self, controller: Any) -> None:
+        pass
+
+    async def put(self, attr: AttrW[T], value: T) -> None:
         await attr.update_display_without_process(value)
 
         if isinstance(attr, AttrRW):
             await attr.set(value)
 
-    async def update(self, attr: AttrR):
+    async def update(self, attr: AttrR) -> None:
         raise RuntimeError("SimpleHandler cannot update")
 
 

--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -32,7 +32,7 @@ class Backend:
     def _link_process_tasks(self):
         for controller_api in self.controller_api.walk_api():
             _link_put_tasks(controller_api)
-            _link_attribute_sender_class(controller_api, self._controller)
+            _link_attribute_sender_class(controller_api)
 
     def __del__(self):
         self._stop_scan_tasks()
@@ -75,9 +75,7 @@ def _link_put_tasks(controller_api: ControllerAPI) -> None:
                 )
 
 
-def _link_attribute_sender_class(
-    controller_api: ControllerAPI, controller: Controller
-) -> None:
+def _link_attribute_sender_class(controller_api: ControllerAPI) -> None:
     for attr_name, attribute in controller_api.attributes.items():
         match attribute:
             case AttrW(sender=Sender()):
@@ -85,13 +83,13 @@ def _link_attribute_sender_class(
                     f"Cannot assign both put method and Sender object to {attr_name}"
                 )
 
-                callback = _create_sender_callback(attribute, controller)
+                callback = _create_sender_callback(attribute)
                 attribute.add_process_callback(callback)
 
 
-def _create_sender_callback(attribute, controller):
+def _create_sender_callback(attribute):
     async def callback(value):
-        await attribute.sender.put(controller, attribute, value)
+        await attribute.sender.put(attribute, value)
 
     return callback
 

--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 from fastcs.cs_methods import Command, Put, Scan
 
-from .attributes import AttrR, AttrW, Setter, Updater
+from .attributes import AttrHandlerR, AttrHandlerW, AttrR, AttrW
 from .controller import BaseController, Controller
 from .controller_api import ControllerAPI
 from .exceptions import FastCSException
@@ -79,7 +79,7 @@ def _link_put_tasks(controller_api: ControllerAPI) -> None:
 def _link_attribute_sender_class(controller_api: ControllerAPI) -> None:
     for attr_name, attribute in controller_api.attributes.items():
         match attribute:
-            case AttrW(sender=Setter()):
+            case AttrW(sender=AttrHandlerW()):
                 assert not attribute.has_process_callback(), (
                     f"Cannot assign both put method and Sender object to {attr_name}"
                 )
@@ -122,7 +122,7 @@ def _add_attribute_updater_tasks(
 ):
     for attribute in controller_api.attributes.values():
         match attribute:
-            case AttrR(updater=Updater(update_period=update_period)) as attribute:
+            case AttrR(updater=AttrHandlerR(update_period=update_period)) as attribute:
                 callback = _create_updater_callback(attribute, controller)
                 if update_period is not None:
                     scan_dict[update_period].append(callback)

--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -26,6 +26,7 @@ class Backend:
 
         # Initialise controller and then build its APIs
         loop.run_until_complete(controller.initialise())
+        loop.run_until_complete(controller.attribute_initialise())
         self.controller_api = build_controller_api(controller)
         self._link_process_tasks()
 

--- a/src/fastcs/backend.py
+++ b/src/fastcs/backend.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 from fastcs.cs_methods import Command, Put, Scan
 
-from .attributes import AttrR, AttrW, Sender, Updater
+from .attributes import AttrR, AttrW, Setter, Updater
 from .controller import BaseController, Controller
 from .controller_api import ControllerAPI
 from .exceptions import FastCSException
@@ -79,7 +79,7 @@ def _link_put_tasks(controller_api: ControllerAPI) -> None:
 def _link_attribute_sender_class(controller_api: ControllerAPI) -> None:
     for attr_name, attribute in controller_api.attributes.items():
         match attribute:
-            case AttrW(sender=Sender()):
+            case AttrW(sender=Setter()):
                 assert not attribute.has_process_callback(), (
                     f"Cannot assign both put method and Sender object to {attr_name}"
                 )

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -30,7 +30,10 @@ class BaseController:
 
         self._bind_attrs()
 
-    async def initialise(self) -> None:
+    async def initialise(self):
+        pass
+
+    async def attribute_initialise(self) -> None:
         # Initialise any registered handlers for attributes
         coros = [attr.initialise(self) for attr in self.attributes.values()]
         try:

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -41,6 +41,9 @@ class BaseController:
         except asyncio.CancelledError:
             pass
 
+        for controller in self.get_sub_controllers().values():
+            await controller.attribute_initialise()
+
     @property
     def path(self) -> list[str]:
         """Path prefix of attributes, recursively including parent Controllers."""

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from copy import copy
+from copy import deepcopy
 from typing import get_type_hints
 
 from fastcs.attributes import Attribute
@@ -91,7 +91,8 @@ class BaseController:
                         f"`{type(self).__name__}` has conflicting attribute "
                         f"`{attr_name}` already present in the attributes dict."
                     )
-                new_attribute = copy(attr)
+
+                new_attribute = deepcopy(attr)
                 setattr(self, attr_name, new_attribute)
                 self.attributes[attr_name] = new_attribute
             elif isinstance(attr, UnboundPut | UnboundScan | UnboundCommand):

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -29,6 +29,11 @@ class BaseController:
 
         self._bind_attrs()
 
+    async def initialise(self) -> None:
+        # Loop over attributes and initialise any registered handlers
+        for attr in self.attributes.values():
+            await attr.initialise(self)
+
     @property
     def path(self) -> list[str]:
         """Path prefix of attributes, recursively including parent Controllers."""
@@ -115,9 +120,6 @@ class Controller(BaseController):
 
     def __init__(self, description: str | None = None) -> None:
         super().__init__(description=description)
-
-    async def initialise(self) -> None:
-        pass
 
     async def connect(self) -> None:
         pass

--- a/src/fastcs/controller.py
+++ b/src/fastcs/controller.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from copy import copy
 from typing import get_type_hints
 
@@ -30,9 +31,12 @@ class BaseController:
         self._bind_attrs()
 
     async def initialise(self) -> None:
-        # Loop over attributes and initialise any registered handlers
-        for attr in self.attributes.values():
-            await attr.initialise(self)
+        # Initialise any registered handlers for attributes
+        coros = [attr.initialise(self) for attr in self.attributes.values()]
+        try:
+            await asyncio.gather(*coros)
+        except asyncio.CancelledError:
+            pass
 
     @property
     def path(self) -> list[str]:

--- a/tests/assertable_controller.py
+++ b/tests/assertable_controller.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pytest_mock import MockerFixture, MockType
 
-from fastcs.attributes import AttrR, Handler, Sender, Updater
+from fastcs.attributes import AttrR, Handler, Setter, Updater
 from fastcs.backend import build_controller_api
 from fastcs.controller import Controller, SubController
 from fastcs.controller_api import ControllerAPI
@@ -22,7 +22,7 @@ class TestUpdater(Updater):
         print(f"{self.controller} update {attr}")
 
 
-class TestSender(Sender):
+class TestSetter(Setter):
     async def initialise(self, controller) -> None:
         self.controller = controller
 
@@ -30,7 +30,7 @@ class TestSender(Sender):
         print(f"{self.controller}: {attr} = {value}")
 
 
-class TestHandler(Handler, TestUpdater, TestSender):
+class TestHandler(Handler, TestUpdater, TestSetter):
     pass
 
 

--- a/tests/assertable_controller.py
+++ b/tests/assertable_controller.py
@@ -15,13 +15,19 @@ from fastcs.wrappers import command, scan
 class TestUpdater(Updater):
     update_period = 1
 
-    async def update(self, controller, attr):
-        print(f"{controller} update {attr}")
+    async def initialise(self, controller) -> None:
+        self.controller = controller
+
+    async def update(self, attr):
+        print(f"{self.controller} update {attr}")
 
 
 class TestSender(Sender):
-    async def put(self, controller, attr, value):
-        print(f"{controller}: {attr} = {value}")
+    async def initialise(self, controller) -> None:
+        self.controller = controller
+
+    async def put(self, attr, value):
+        print(f"{self.controller}: {attr} = {value}")
 
 
 class TestHandler(Handler, TestUpdater, TestSender):
@@ -47,6 +53,7 @@ class MyTestController(Controller):
     count = 0
 
     async def initialise(self) -> None:
+        await super().initialise()
         self.initialised = True
 
     async def connect(self) -> None:

--- a/tests/assertable_controller.py
+++ b/tests/assertable_controller.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pytest_mock import MockerFixture, MockType
 
-from fastcs.attributes import AttrR, Handler, Setter, Updater
+from fastcs.attributes import AttrHandlerR, AttrHandlerRW, AttrHandlerW, AttrR
 from fastcs.backend import build_controller_api
 from fastcs.controller import Controller, SubController
 from fastcs.controller_api import ControllerAPI
@@ -12,7 +12,7 @@ from fastcs.datatypes import Int
 from fastcs.wrappers import command, scan
 
 
-class TestUpdater(Updater):
+class TestUpdater(AttrHandlerR):
     update_period = 1
 
     async def initialise(self, controller) -> None:
@@ -22,7 +22,7 @@ class TestUpdater(Updater):
         print(f"{self.controller} update {attr}")
 
 
-class TestSetter(Setter):
+class TestSetter(AttrHandlerW):
     async def initialise(self, controller) -> None:
         self.controller = controller
 
@@ -30,7 +30,7 @@ class TestSetter(Setter):
         print(f"{self.controller}: {attr} = {value}")
 
 
-class TestHandler(Handler, TestUpdater, TestSetter):
+class TestHandler(AttrHandlerRW, TestUpdater, TestSetter):
     pass
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from fastcs.transport.tango.dsr import register_dev
 from tests.assertable_controller import (
     MyTestController,
     TestHandler,
-    TestSender,
+    TestSetter,
     TestUpdater,
 )
 from tests.example_p4p_ioc import run as _run_p4p_ioc
@@ -37,7 +37,7 @@ class BackendTestController(MyTestController):
     read_write_int: AttrRW = AttrRW(Int(), handler=TestHandler())
     read_write_float: AttrRW = AttrRW(Float())
     read_bool: AttrR = AttrR(Bool())
-    write_bool: AttrW = AttrW(Bool(), handler=TestSender())
+    write_bool: AttrW = AttrW(Bool(), handler=TestSetter())
     read_string: AttrRW = AttrRW(String())
 
 

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -69,7 +69,7 @@ async def test_handler_initialise(mocker: MockerFixture):
     await attr.initialise(mocker.ANY)
 
     # The handler initialise method should be called from the attribute
-    handler_mock.assert_called_once_with(1)
+    handler_mock.assert_called_once_with(mocker.ANY)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -70,10 +70,11 @@ async def test_handler_initialise(mocker: MockerFixture):
     handler_mock = mocker.patch.object(handler, "initialise")
     attr = AttrR(Int(), handler=handler)
 
-    await attr.initialise(mocker.ANY)
+    ctrlr = mocker.Mock()
+    await attr.initialise(ctrlr)
 
     # The handler initialise method should be called from the attribute
-    handler_mock.assert_called_once_with(mocker.ANY)
+    handler_mock.assert_called_once_with(ctrlr)
 
     handler = SimpleHandler()
     attr = AttrW(Int(), handler=handler)

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
-from fastcs.attributes import AttrR, AttrRW, AttrW, SimpleHandler
+from fastcs.attributes import AttrR, AttrRW, AttrW, SimpleHandler, Updater
 from fastcs.datatypes import Enum, Float, Int, String, Waveform
 
 
@@ -60,6 +60,10 @@ async def test_simple_handler_rw(mocker: MockerFixture):
     set_mock.assert_awaited_once_with(1)
 
 
+class SimpleUpdater(Updater):
+    pass
+
+
 @pytest.mark.asyncio
 async def test_handler_initialise(mocker: MockerFixture):
     handler = SimpleHandler()
@@ -75,6 +79,12 @@ async def test_handler_initialise(mocker: MockerFixture):
     attr = AttrW(Int(), handler=handler)
 
     # Assert no error in calling initialise on the SimpleHandler default
+    await attr.initialise(mocker.ANY)
+
+    handler = SimpleUpdater()
+    attr = AttrR(Int(), handler=handler)
+
+    # Assert no error in calling initialise on the TestUpdater handler
     await attr.initialise(mocker.ANY)
 
 

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
-from fastcs.attributes import AttrR, AttrRW, AttrW
+from fastcs.attributes import AttrR, AttrRW, AttrW, SimpleHandler
 from fastcs.datatypes import Enum, Float, Int, String, Waveform
 
 
@@ -58,6 +58,18 @@ async def test_simple_handler_rw(mocker: MockerFixture):
     update_display_mock.assert_called_once_with(1)
     # The Sender of the attribute should just set the value on the attribute
     set_mock.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_handler_initialise(mocker: MockerFixture):
+    handler = SimpleHandler()
+    handler_mock = mocker.patch.object(handler, "initialise")
+    attr = AttrR(Int(), handler=handler)
+
+    await attr.initialise(mocker.ANY)
+
+    # The handler initialise method should be called from the attribute
+    handler_mock.assert_called_once_with(1)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -41,7 +41,7 @@ async def test_simple_handler_w(mocker: MockerFixture):
     update_display_mock = mocker.patch.object(attr, "update_display_without_process")
 
     # This is called by the transport when it receives a put
-    await attr.sender.put(mocker.ANY, attr, 1)
+    await attr.sender.put(attr, 1)
 
     # The callback to update the transport display should be called
     update_display_mock.assert_called_once_with(1)
@@ -53,7 +53,7 @@ async def test_simple_handler_rw(mocker: MockerFixture):
     update_display_mock = mocker.patch.object(attr, "update_display_without_process")
     set_mock = mocker.patch.object(attr, "set")
 
-    await attr.sender.put(mocker.ANY, attr, 1)
+    await attr.sender.put(attr, 1)
 
     update_display_mock.assert_called_once_with(1)
     # The Sender of the attribute should just set the value on the attribute

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -71,6 +71,12 @@ async def test_handler_initialise(mocker: MockerFixture):
     # The handler initialise method should be called from the attribute
     handler_mock.assert_called_once_with(mocker.ANY)
 
+    handler = SimpleHandler()
+    attr = AttrW(Int(), handler=handler)
+
+    # Assert no error in calling initialise on the SimpleHandler default
+    await attr.initialise(mocker.ANY)
+
 
 @pytest.mark.parametrize(
     ["datatype", "init_args", "value"],

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
-from fastcs.attributes import AttrR, AttrRW, AttrW, SimpleHandler, Updater
+from fastcs.attributes import AttrHandlerR, AttrHandlerRW, AttrR, AttrRW, AttrW
 from fastcs.datatypes import Enum, Float, Int, String, Waveform
 
 
@@ -60,13 +60,13 @@ async def test_simple_handler_rw(mocker: MockerFixture):
     set_mock.assert_awaited_once_with(1)
 
 
-class SimpleUpdater(Updater):
+class SimpleUpdater(AttrHandlerR):
     pass
 
 
 @pytest.mark.asyncio
 async def test_handler_initialise(mocker: MockerFixture):
-    handler = SimpleHandler()
+    handler = AttrHandlerRW()
     handler_mock = mocker.patch.object(handler, "initialise")
     attr = AttrR(Int(), handler=handler)
 
@@ -76,7 +76,7 @@ async def test_handler_initialise(mocker: MockerFixture):
     # The handler initialise method should be called from the attribute
     handler_mock.assert_called_once_with(ctrlr)
 
-    handler = SimpleHandler()
+    handler = AttrHandlerRW()
     attr = AttrW(Int(), handler=handler)
 
     # Assert no error in calling initialise on the SimpleHandler default

--- a/tests/transport/epics/ca/test_softioc.py
+++ b/tests/transport/epics/ca/test_softioc.py
@@ -8,7 +8,7 @@ from tests.assertable_controller import (
     AssertableControllerAPI,
     MyTestController,
     TestHandler,
-    TestSender,
+    TestSetter,
     TestUpdater,
 )
 from tests.util import ColourEnum
@@ -213,7 +213,7 @@ class EpicsController(MyTestController):
     read_write_int = AttrRW(Int(), handler=TestHandler())
     read_write_float = AttrRW(Float())
     read_bool = AttrR(Bool())
-    write_bool = AttrW(Bool(), handler=TestSender())
+    write_bool = AttrW(Bool(), handler=TestSetter())
     read_string = AttrRW(String())
     enum = AttrRW(Enum(enum.IntEnum("Enum", {"RED": 0, "GREEN": 1, "BLUE": 2})))
     one_d_waveform = AttrRW(Waveform(np.int32, (10,)))

--- a/tests/transport/graphQL/test_graphQL.py
+++ b/tests/transport/graphQL/test_graphQL.py
@@ -9,7 +9,7 @@ from tests.assertable_controller import (
     AssertableControllerAPI,
     MyTestController,
     TestHandler,
-    TestSender,
+    TestSetter,
     TestUpdater,
 )
 
@@ -23,7 +23,7 @@ class GraphQLController(MyTestController):
     read_write_int = AttrRW(Int(), handler=TestHandler())
     read_write_float = AttrRW(Float())
     read_bool = AttrR(Bool())
-    write_bool = AttrW(Bool(), handler=TestSender())
+    write_bool = AttrW(Bool(), handler=TestSetter())
     read_string = AttrRW(String())
 
 

--- a/tests/transport/rest/test_rest.py
+++ b/tests/transport/rest/test_rest.py
@@ -8,7 +8,7 @@ from tests.assertable_controller import (
     AssertableControllerAPI,
     MyTestController,
     TestHandler,
-    TestSender,
+    TestSetter,
     TestUpdater,
 )
 
@@ -23,7 +23,7 @@ class RestController(MyTestController):
     read_write_int = AttrRW(Int(), handler=TestHandler())
     read_write_float = AttrRW(Float())
     read_bool = AttrR(Bool())
-    write_bool = AttrW(Bool(), handler=TestSender())
+    write_bool = AttrW(Bool(), handler=TestSetter())
     read_string = AttrRW(String())
     enum = AttrRW(Enum(enum.IntEnum("Enum", {"RED": 0, "GREEN": 1, "BLUE": 2})))
     one_d_waveform = AttrRW(Waveform(np.int32, (10,)))

--- a/tests/transport/tango/test_dsr.py
+++ b/tests/transport/tango/test_dsr.py
@@ -10,7 +10,7 @@ from tests.assertable_controller import (
     AssertableControllerAPI,
     MyTestController,
     TestHandler,
-    TestSender,
+    TestSetter,
     TestUpdater,
 )
 
@@ -37,7 +37,7 @@ class TangoController(MyTestController):
     read_write_int = AttrRW(Int(), handler=TestHandler())
     read_write_float = AttrRW(Float())
     read_bool = AttrR(Bool())
-    write_bool = AttrW(Bool(), handler=TestSender())
+    write_bool = AttrW(Bool(), handler=TestSetter())
     read_string = AttrRW(String())
     enum = AttrRW(Enum(enum.IntEnum("Enum", {"RED": 0, "GREEN": 1, "BLUE": 2})))
     one_d_waveform = AttrRW(Waveform(np.int32, (10,)))


### PR DESCRIPTION
Resolves #59 
Added default initialise methods to Sender and Updater base classes.
Added initialise method to Attribute, checks for handler and calls the method.
Moved initialise into BaseController class, loops over attributes calling initialise with a reference to self.
Added unit test for Attribute class.

Fixes #59 
Fixes #130 