### PR TITLE
fix: Prevent grouping attributes in the pva pvi.

### DIFF
--- a/src/fastcs/transport/epics/pva/pvi_tree.py
+++ b/src/fastcs/transport/epics/pva/pvi_tree.py
@@ -76,15 +76,20 @@ class PviDevice(dict[str, "PviDevice"]):
     def _make_p4p_raw_value(self) -> dict:
         p4p_raw_value = defaultdict(dict)
         for pv_leaf, signal_info in self._get_signal_infos().items():
-            pvi_name, number = _pv_to_pvi_name(pv_leaf.rstrip(":PVI") or pv_leaf)
-            if number is not None:
+            stripped_leaf = pv_leaf.rstrip(":PVI")
+            is_controller = stripped_leaf != pv_leaf
+            pvi_name, number = _pv_to_pvi_name(stripped_leaf or pv_leaf)
+            if is_controller and number is not None:
                 if signal_info.access not in p4p_raw_value[pvi_name]:
                     p4p_raw_value[pvi_name][signal_info.access] = {}
                 p4p_raw_value[pvi_name][signal_info.access][f"v{number}"] = (
                     signal_info.pv
                 )
-            else:
+            elif is_controller:
                 p4p_raw_value[pvi_name][signal_info.access] = signal_info.pv
+            else:
+                attr_pvi_name = f"{pvi_name}{'' if number is None else number}"
+                p4p_raw_value[attr_pvi_name][signal_info.access] = signal_info.pv
 
         return p4p_raw_value
 

--- a/tests/transport/epics/pva/test_p4p.py
+++ b/tests/transport/epics/pva/test_p4p.py
@@ -352,14 +352,10 @@ def test_pvi_grouping():
             "value": {
                 "additional_child": {"d": f"{pv_prefix}:AdditionalChild:PVI"},
                 "another_child": {"d": f"{pv_prefix}:AnotherChild:PVI"},
-                "another_attr": {
-                    "rw": {
-                        "v0": f"{pv_prefix}:AnotherAttr0",
-                        "v1000": f"{pv_prefix}:AnotherAttr1000",
-                    }
-                },
+                "another_attr0": {"rw": f"{pv_prefix}:AnotherAttr0"},
+                "another_attr1000": {"rw": f"{pv_prefix}:AnotherAttr1000"},
                 "a_third_attr": {"w": f"{pv_prefix}:AThirdAttr"},
-                "attr": {"rw": {"v1": f"{pv_prefix}:Attr1"}},
+                "attr1": {"rw": f"{pv_prefix}:Attr1"},
                 "child": {
                     "d": {
                         "v0": f"{pv_prefix}:Child0:PVI",


### PR DESCRIPTION
Unlike controllers, attributes should not be grouped in the pva pvi tree.