### PR TITLE
feature: gui and docs can be `None` in a transport

### DIFF
--- a/src/fastcs/launch.py
+++ b/src/fastcs/launch.py
@@ -83,12 +83,12 @@ class FastCS:
 
     def create_docs(self) -> None:
         for transport in self._transports:
-            if hasattr(transport.options, "docs"):
+            if getattr(transport.options, "docs", None) is not None:
                 transport.create_docs()
 
     def create_gui(self) -> None:
         for transport in self._transports:
-            if hasattr(transport.options, "gui"):
+            if getattr(transport.options, "gui", None) is not None:
                 transport.create_gui()
 
     def run(self):

--- a/src/fastcs/transport/epics/ca/options.py
+++ b/src/fastcs/transport/epics/ca/options.py
@@ -11,6 +11,6 @@ from ..options import (
 class EpicsCAOptions:
     """Options for the EPICS CA transport."""
 
-    docs: EpicsDocsOptions = field(default_factory=EpicsDocsOptions)
-    gui: EpicsGUIOptions = field(default_factory=EpicsGUIOptions)
+    docs: EpicsDocsOptions | None = None
+    gui: EpicsGUIOptions | None = None
     ioc: EpicsIOCOptions = field(default_factory=EpicsIOCOptions)

--- a/src/fastcs/transport/epics/gui.py
+++ b/src/fastcs/transport/epics/gui.py
@@ -25,7 +25,7 @@ from pydantic import ValidationError
 from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW
 from fastcs.controller_api import ControllerAPI
 from fastcs.cs_methods import Command
-from fastcs.datatypes import Bool, Enum, Float, Int, String, Waveform
+from fastcs.datatypes import Bool, Enum, Float, Int, String, Table, Waveform
 from fastcs.exceptions import FastCSException
 from fastcs.util import snake_to_pascal
 
@@ -56,6 +56,8 @@ class EpicsGUI:
                 return TextRead(format=TextFormat.string)
             case Waveform():
                 return None
+            case Table():
+                return None
             case datatype:
                 raise FastCSException(f"Unsupported type {type(datatype)}: {datatype}")
 
@@ -73,6 +75,8 @@ class EpicsGUI:
                     choices=[member.name for member in attribute.datatype.members]
                 )
             case Waveform():
+                return None
+            case Table():
                 return None
             case datatype:
                 raise FastCSException(f"Unsupported type {type(datatype)}: {datatype}")

--- a/src/fastcs/transport/epics/pva/options.py
+++ b/src/fastcs/transport/epics/pva/options.py
@@ -11,6 +11,6 @@ from fastcs.transport.epics.options import (
 class EpicsPVAOptions:
     """Options for the EPICS PVA transport."""
 
-    docs: EpicsDocsOptions = field(default_factory=EpicsDocsOptions)
-    gui: EpicsGUIOptions = field(default_factory=EpicsGUIOptions)
+    docs: EpicsDocsOptions | None = None
+    gui: EpicsGUIOptions | None = None
     ioc: EpicsIOCOptions = field(default_factory=EpicsIOCOptions)

--- a/tests/data/schema.json
+++ b/tests/data/schema.json
@@ -3,10 +3,26 @@
     "EpicsCAOptions": {
       "properties": {
         "docs": {
-          "$ref": "#/$defs/EpicsDocsOptions"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpicsDocsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "gui": {
-          "$ref": "#/$defs/EpicsGUIOptions"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpicsGUIOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "ioc": {
           "$ref": "#/$defs/EpicsIOCOptions"
@@ -83,10 +99,26 @@
     "EpicsPVAOptions": {
       "properties": {
         "docs": {
-          "$ref": "#/$defs/EpicsDocsOptions"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpicsDocsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "gui": {
-          "$ref": "#/$defs/EpicsGUIOptions"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpicsGUIOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "ioc": {
           "$ref": "#/$defs/EpicsIOCOptions"


### PR DESCRIPTION
Allows for optional creation of gui and docs.

Also fixes pva GUI by skipping `fastcs.datatypes.Table`.