### PR TITLE
Allow creating CA IOCs via yaml config

### DIFF
--- a/docs/snippets/dynamic.py
+++ b/docs/snippets/dynamic.py
@@ -112,7 +112,7 @@ class TemperatureController(Controller):
         await self.connection.close()
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(connection_settings), [epics_options])
 

--- a/docs/snippets/static04.py
+++ b/docs/snippets/static04.py
@@ -10,7 +10,7 @@ class TemperatureController(Controller):
     device_id = AttrR(String())
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 fastcs = FastCS(TemperatureController(), [epics_options])
 
 # fastcs.run()  # Commented as this will block

--- a/docs/snippets/static05.py
+++ b/docs/snippets/static05.py
@@ -20,7 +20,7 @@ class TemperatureController(Controller):
         await self.connection.connect(self._ip_settings)
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(connection_settings), [epics_options])
 

--- a/docs/snippets/static06.py
+++ b/docs/snippets/static06.py
@@ -47,7 +47,7 @@ class TemperatureController(Controller):
         await self.connection.connect(self._ip_settings)
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(connection_settings), [epics_options])
 

--- a/docs/snippets/static07.py
+++ b/docs/snippets/static07.py
@@ -51,7 +51,7 @@ class TemperatureController(Controller):
         await self.connection.connect(self._ip_settings)
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(connection_settings), [epics_options])
 

--- a/docs/snippets/static08.py
+++ b/docs/snippets/static08.py
@@ -58,7 +58,7 @@ class TemperatureController(Controller):
         await self.connection.connect(self._ip_settings)
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(connection_settings), [epics_options])
 

--- a/docs/snippets/static09.py
+++ b/docs/snippets/static09.py
@@ -78,7 +78,7 @@ class TemperatureController(Controller):
         await self.connection.connect(self._ip_settings)
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(4, connection_settings), [epics_options])
 

--- a/docs/snippets/static10.py
+++ b/docs/snippets/static10.py
@@ -85,7 +85,7 @@ class TemperatureController(Controller):
         await self.connection.connect(self._ip_settings)
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(4, connection_settings), [epics_options])
 

--- a/docs/snippets/static11.py
+++ b/docs/snippets/static11.py
@@ -98,7 +98,7 @@ class TemperatureController(Controller):
             await controller.voltage.set(float(voltages[index]))
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(4, connection_settings), [epics_options])
 

--- a/docs/snippets/static12.py
+++ b/docs/snippets/static12.py
@@ -106,7 +106,7 @@ class TemperatureController(Controller):
             await asyncio.sleep(0.1)
 
 
-epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix="DEMO"))
+epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix="DEMO"))
 connection_settings = IPConnectionSettings("localhost", 25565)
 fastcs = FastCS(TemperatureController(4, connection_settings), [epics_options])
 

--- a/src/fastcs/demo/controller.yaml
+++ b/src/fastcs/demo/controller.yaml
@@ -9,7 +9,7 @@ transport:
       host: localhost
       port: 8083
       log_level: info
-  - ioc:
+  - ca_ioc:
       pv_prefix: GARY
     gui:
       title: Temperature Controller Demo

--- a/src/fastcs/transport/epics/ca/adapter.py
+++ b/src/fastcs/transport/epics/ca/adapter.py
@@ -20,11 +20,11 @@ class EpicsCATransport(TransportAdapter):
         self._controller_api = controller_api
         self._loop = loop
         self._options = options or EpicsCAOptions()
-        self._pv_prefix = self.options.ioc.pv_prefix
+        self._pv_prefix = self.options.ca_ioc.pv_prefix
         self._ioc = EpicsCAIOC(
-            self.options.ioc.pv_prefix,
+            self.options.ca_ioc.pv_prefix,
             controller_api,
-            self._options.ioc,
+            self._options.ca_ioc,
         )
 
     @property

--- a/src/fastcs/transport/epics/ca/options.py
+++ b/src/fastcs/transport/epics/ca/options.py
@@ -13,4 +13,4 @@ class EpicsCAOptions:
 
     docs: EpicsDocsOptions = field(default_factory=EpicsDocsOptions)
     gui: EpicsGUIOptions = field(default_factory=EpicsGUIOptions)
-    ioc: EpicsIOCOptions = field(default_factory=EpicsIOCOptions)
+    ca_ioc: EpicsIOCOptions = field(default_factory=EpicsIOCOptions)

--- a/src/fastcs/transport/epics/pva/adapter.py
+++ b/src/fastcs/transport/epics/pva/adapter.py
@@ -17,8 +17,8 @@ class EpicsPVATransport(TransportAdapter):
     ) -> None:
         self._controller_api = controller_api
         self._options = options or EpicsPVAOptions()
-        self._pv_prefix = self.options.ioc.pv_prefix
-        self._ioc = P4PIOC(self.options.ioc.pv_prefix, controller_api)
+        self._pv_prefix = self.options.pva_ioc.pv_prefix
+        self._ioc = P4PIOC(self.options.pva_ioc.pv_prefix, controller_api)
 
     @property
     def options(self) -> EpicsPVAOptions:

--- a/src/fastcs/transport/epics/pva/options.py
+++ b/src/fastcs/transport/epics/pva/options.py
@@ -13,4 +13,4 @@ class EpicsPVAOptions:
 
     docs: EpicsDocsOptions = field(default_factory=EpicsDocsOptions)
     gui: EpicsGUIOptions = field(default_factory=EpicsGUIOptions)
-    ioc: EpicsIOCOptions = field(default_factory=EpicsIOCOptions)
+    pva_ioc: EpicsIOCOptions = field(default_factory=EpicsIOCOptions)

--- a/tests/benchmarking/controller.py
+++ b/tests/benchmarking/controller.py
@@ -17,7 +17,7 @@ def run():
     transport_options = [
         RestOptions(rest=RestServerOptions(port=8090)),
         EpicsCAOptions(
-            ioc=EpicsIOCOptions(pv_prefix="BENCHMARK-DEVICE"),
+            ca_ioc=EpicsIOCOptions(pv_prefix="BENCHMARK-DEVICE"),
         ),
         TangoOptions(dsr=TangoDSROptions(dev_name="MY/BENCHMARK/DEVICE")),
     ]

--- a/tests/data/config.yaml
+++ b/tests/data/config.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=schema.json
 transport:
-  - ioc: {}
+  - ca_ioc: {}
     docs: {}
     gui: {}
   - rest: {}

--- a/tests/data/schema.json
+++ b/tests/data/schema.json
@@ -8,7 +8,7 @@
         "gui": {
           "$ref": "#/$defs/EpicsGUIOptions"
         },
-        "ioc": {
+        "ca_ioc": {
           "$ref": "#/$defs/EpicsIOCOptions"
         }
       },
@@ -88,7 +88,7 @@
         "gui": {
           "$ref": "#/$defs/EpicsGUIOptions"
         },
-        "ioc": {
+        "pva_ioc": {
           "$ref": "#/$defs/EpicsIOCOptions"
         }
       },

--- a/tests/example_p4p_ioc.py
+++ b/tests/example_p4p_ioc.py
@@ -65,7 +65,7 @@ class ChildController(SubController):
 
 
 def run(pv_prefix="P4P_TEST_DEVICE"):
-    p4p_options = EpicsPVAOptions(ioc=EpicsIOCOptions(pv_prefix=pv_prefix))
+    p4p_options = EpicsPVAOptions(pva_ioc=EpicsIOCOptions(pv_prefix=pv_prefix))
     controller = ParentController()
     controller.register_sub_controller(
         "Child1", ChildController(description="some sub controller")

--- a/tests/example_softioc.py
+++ b/tests/example_softioc.py
@@ -21,7 +21,7 @@ class ChildController(SubController):
 
 
 def run(pv_prefix="SOFTIOC_TEST_DEVICE"):
-    epics_options = EpicsCAOptions(ioc=EpicsIOCOptions(pv_prefix=pv_prefix))
+    epics_options = EpicsCAOptions(ca_ioc=EpicsIOCOptions(pv_prefix=pv_prefix))
     controller = ParentController()
     controller.register_sub_controller("Child", ChildController())
     fastcs = FastCS(controller, [epics_options])

--- a/tests/regenerate_test_output.sh
+++ b/tests/regenerate_test_output.sh
@@ -1,0 +1,8 @@
+# If you changed some code which you expect to change the output files, then run
+# this script to regenerate the test output.
+#
+# NOTE: Do not run this script unless you are expecting the output files to
+# change. Examine the git diff carefully to make sure the new test output files
+# are as you expect them to be
+
+cd $(dirname $0)/.. && FASTCS_REGENERATE_OUTPUT=1 pytest .

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,4 +1,5 @@
 import json
+import os
 from dataclasses import dataclass
 
 import pytest
@@ -137,6 +138,10 @@ def test_launch(mocker: MockerFixture, data):
 
 
 def test_get_schema(data):
-    ref_schema = YAML(typ="safe").load(data / "schema.json")
     target_schema = get_controller_schema(IsHinted)
+    if os.environ.get("FASTCS_REGENERATE_OUTPUT", None):
+        with open(data / "schema.json", "w") as f:
+            json.dump(target_schema, f, indent=2)
+
+    ref_schema = YAML(typ="safe").load(data / "schema.json")
     assert target_schema == ref_schema

--- a/tests/transport/epics/pva/test_p4p.py
+++ b/tests/transport/epics/pva/test_p4p.py
@@ -231,7 +231,7 @@ async def test_numerical_alarms(p4p_subprocess: tuple[str, Queue]):
 
 
 def make_fastcs(pv_prefix: str, controller: Controller) -> FastCS:
-    epics_options = EpicsPVAOptions(ioc=EpicsIOCOptions(pv_prefix=pv_prefix))
+    epics_options = EpicsPVAOptions(pva_ioc=EpicsIOCOptions(pv_prefix=pv_prefix))
     return FastCS(controller, [epics_options])
 
 


### PR DESCRIPTION
This enables creating either ca or pva IOCs via yaml config by giving them uniquely named fields.

Fixes #145 