### PR TITLE
Add table support in pva and fix gui pv naming

### DIFF
--- a/src/fastcs/transport/epics/gui.py
+++ b/src/fastcs/transport/epics/gui.py
@@ -227,10 +227,11 @@ class PvaEpicsGUI(EpicsGUI):
             widgets = []
             for _, datatype in fastcs_datatype.structured_dtype:
                 fastcs_datatype = numpy_to_fastcs_datatype(datatype)
-                widget = super()._get_write_widget(fastcs_datatype)
-                if isinstance(widget, ToggleButton):
+                if isinstance(fastcs_datatype, Bool):
                     # Replace with compact version for Table row
                     widget = CheckBox()
+                else:
+                    widget = super()._get_write_widget(fastcs_datatype)
                 widgets.append(widget)
             return TableWrite(widgets=widgets)
         else:

--- a/src/fastcs/transport/epics/gui.py
+++ b/src/fastcs/transport/epics/gui.py
@@ -40,7 +40,9 @@ class EpicsGUI:
         self._pv_prefix = pv_prefix
 
     def _get_pv(self, attr_path: list[str], name: str):
-        attr_prefix = ":".join([self._pv_prefix] + attr_path)
+        attr_prefix = ":".join(
+            [self._pv_prefix] + [snake_to_pascal(attr) for attr in attr_path]
+        )
         return f"{attr_prefix}:{snake_to_pascal(name)}"
 
     @staticmethod

--- a/src/fastcs/transport/epics/gui.py
+++ b/src/fastcs/transport/epics/gui.py
@@ -52,7 +52,7 @@ class EpicsGUI:
 
     def _get_pv(self, attr_path: list[str], name: str):
         attr_prefix = ":".join(
-            [self._pv_prefix] + [snake_to_pascal(attr) for attr in attr_path]
+            [self._pv_prefix] + [snake_to_pascal(node) for node in attr_path]
         )
         return f"{attr_prefix}:{snake_to_pascal(name)}"
 

--- a/src/fastcs/transport/epics/pva/adapter.py
+++ b/src/fastcs/transport/epics/pva/adapter.py
@@ -1,7 +1,7 @@
 from fastcs.controller_api import ControllerAPI
 from fastcs.transport.adapter import TransportAdapter
 from fastcs.transport.epics.docs import EpicsDocs
-from fastcs.transport.epics.gui import EpicsGUI
+from fastcs.transport.epics.gui import PvaEpicsGUI
 from fastcs.transport.epics.pva.options import EpicsPVAOptions
 
 from .ioc import P4PIOC
@@ -32,4 +32,4 @@ class EpicsPVATransport(TransportAdapter):
         EpicsDocs(self._controller_api).create_docs(self.options.docs)
 
     def create_gui(self) -> None:
-        EpicsGUI(self._controller_api, self._pv_prefix).create_gui(self.options.gui)
+        PvaEpicsGUI(self._controller_api, self._pv_prefix).create_gui(self.options.gui)

--- a/src/fastcs/util.py
+++ b/src/fastcs/util.py
@@ -1,5 +1,9 @@
 import re
 
+import numpy as np
+
+from fastcs.datatypes import Bool, DataType, Float, Int, String
+
 
 def snake_to_pascal(name: str) -> str:
     """Converts string from snake case to Pascal case.
@@ -8,3 +12,14 @@ def snake_to_pascal(name: str) -> str:
     if re.fullmatch(r"[a-z][a-z0-9]*(?:_[a-z0-9]+)*", name):
         name = re.sub(r"(?:^|_)([a-z0-9])", lambda match: match.group(1).upper(), name)
     return name
+
+
+def numpy_to_fastcs_datatype(np_type) -> DataType:
+    if np.issubdtype(np_type, np.integer):
+        return Int()
+    elif np.issubdtype(np_type, np.floating):
+        return Float()
+    elif np.issubdtype(np_type, np.bool_):
+        return Bool()
+    else:
+        return String()

--- a/src/fastcs/util.py
+++ b/src/fastcs/util.py
@@ -15,6 +15,9 @@ def snake_to_pascal(name: str) -> str:
 
 
 def numpy_to_fastcs_datatype(np_type) -> DataType:
+    """Converts numpy types to fastcs types for widget creation.
+    Only types important for widget creation are explicitly converted
+    """
     if np.issubdtype(np_type, np.integer):
         return Int()
     elif np.issubdtype(np_type, np.floating):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,10 @@
+import numpy as np
 import pytest
 from pvi.device import SignalR
 from pydantic import ValidationError
 
-from fastcs.util import snake_to_pascal
+from fastcs.datatypes import Bool, Float, Int, String
+from fastcs.util import numpy_to_fastcs_datatype, snake_to_pascal
 
 
 def test_snake_to_pascal():
@@ -36,3 +38,21 @@ def test_pvi_validation_error():
     name = snake_to_pascal("Name-With_%_Invalid-&-Symbols_£_")
     with pytest.raises(ValidationError):
         SignalR(name=name, read_pv="test")
+
+
+@pytest.mark.parametrize(
+    "numpy_type, fastcs_datatype",
+    [
+        (np.float16, Float()),
+        (np.float32, Float()),
+        (np.int16, Int()),
+        (np.int32, Int()),
+        (np.bool, Bool()),
+        (np.dtype("S1000"), String()),
+        (np.dtype("U25"), String()),
+        (np.dtype(">i4"), Int()),
+        (np.dtype("d"), Float()),
+    ],
+)
+def test_numpy_to_fastcs_datatype(numpy_type, fastcs_datatype):
+    assert fastcs_datatype == numpy_to_fastcs_datatype(numpy_type)

--- a/tests/transport/epics/ca/test_gui.py
+++ b/tests/transport/epics/ca/test_gui.py
@@ -79,12 +79,12 @@ def test_get_attribute_component_none(mocker, controller_api):
 
 
 def test_get_read_widget_none(controller_api):
-    gui = EpicsGUI(controller_api, "DEVICe")
+    gui = EpicsGUI(controller_api, "DEVICE")
     assert gui._get_read_widget(fastcs_datatype=Waveform(np.int32)) is None
 
 
 def test_get_write_widget_none(controller_api):
-    gui = EpicsGUI(controller_api, "DEVICe")
+    gui = EpicsGUI(controller_api, "DEVICE")
     assert gui._get_write_widget(fastcs_datatype=Waveform(np.int32)) is None
 
 

--- a/tests/transport/epics/ca/test_gui.py
+++ b/tests/transport/epics/ca/test_gui.py
@@ -78,12 +78,14 @@ def test_get_attribute_component_none(mocker, controller_api):
     assert gui._get_attribute_component([], "Attr", AttrRW(Int())) is None
 
 
-def test_get_read_widget_none():
-    assert EpicsGUI._get_read_widget(AttrR(Waveform(np.int32))) is None
+def test_get_read_widget_none(controller_api):
+    gui = EpicsGUI(controller_api, "DEVICe")
+    assert gui._get_read_widget(fastcs_datatype=Waveform(np.int32)) is None
 
 
-def test_get_write_widget_none():
-    assert EpicsGUI._get_write_widget(AttrW(Waveform(np.int32))) is None
+def test_get_write_widget_none(controller_api):
+    gui = EpicsGUI(controller_api, "DEVICe")
+    assert gui._get_write_widget(fastcs_datatype=Waveform(np.int32)) is None
 
 
 def test_get_components(controller_api):

--- a/tests/transport/epics/pva/test_pva_gui.py
+++ b/tests/transport/epics/pva/test_pva_gui.py
@@ -1,0 +1,46 @@
+from numpy import uint32
+from pvi.device import (
+    LED,
+    SignalR,
+    SignalW,
+    TableRead,
+    TableWrite,
+    TextRead,
+    TextWrite,
+)
+
+from fastcs.attributes import AttrR, AttrW
+from fastcs.datatypes import Table
+from fastcs.transport.epics.gui import PvaEpicsGUI
+
+
+def test_get_pv_in_pva(controller_api):
+    gui = PvaEpicsGUI(controller_api, "DEVICE")
+
+    assert gui._get_pv([], "A") == "pva://DEVICE:A"
+    assert gui._get_pv(["B"], "C") == "pva://DEVICE:B:C"
+    assert gui._get_pv(["D", "E"], "F") == "pva://DEVICE:D:E:F"
+
+
+def test_get_attribute_component_table_write(controller_api):
+    gui = PvaEpicsGUI(controller_api, "DEVICE")
+
+    assert gui._get_attribute_component(
+        [], "Table", AttrW(Table(structured_dtype=[("FIELD", uint32)]))
+    ) == SignalW(
+        name="Table", write_pv="Table", write_widget=TableWrite(widgets=[TextWrite()])
+    )
+
+
+def test_get_attribute_component_table_read(controller_api):
+    gui = PvaEpicsGUI(controller_api, "DEVICE")
+
+    assert gui._get_attribute_component(
+        [], "Table", AttrR(Table(structured_dtype=[("FIELD", uint32)]))
+    ) == SignalR(
+        name="Table",
+        read_pv="Table",
+        read_widget=TableRead(
+            widgets=[TextRead()] * 4 + [LED()] * 6 + [TextRead()] + [LED()] * 6
+        ),
+    )

--- a/tests/transport/epics/pva/test_pva_gui.py
+++ b/tests/transport/epics/pva/test_pva_gui.py
@@ -1,10 +1,12 @@
-from numpy import uint32
+import numpy as np
 from pvi.device import (
     LED,
+    CheckBox,
     SignalR,
     SignalW,
     TableRead,
     TableWrite,
+    TextFormat,
     TextRead,
     TextWrite,
 )
@@ -25,22 +27,50 @@ def test_get_pv_in_pva(controller_api):
 def test_get_attribute_component_table_write(controller_api):
     gui = PvaEpicsGUI(controller_api, "DEVICE")
 
-    assert gui._get_attribute_component(
-        [], "Table", AttrW(Table(structured_dtype=[("FIELD", uint32)]))
-    ) == SignalW(
-        name="Table", write_pv="Table", write_widget=TableWrite(widgets=[TextWrite()])
+    attribute_component = gui._get_attribute_component(
+        [],
+        "Table",
+        AttrW(
+            Table(
+                structured_dtype=[
+                    ("FIELD1", np.uint32),
+                    ("FIELD2", np.bool),
+                    ("FIELD3", np.dtype("S1000")),
+                ]
+            )
+        ),
     )
+
+    assert isinstance(attribute_component, SignalW)
+    assert isinstance(attribute_component.write_widget, TableWrite)
+    assert attribute_component.write_widget.widgets == [
+        TextWrite(),
+        CheckBox(),
+        TextWrite(format=TextFormat.string),
+    ]
 
 
 def test_get_attribute_component_table_read(controller_api):
     gui = PvaEpicsGUI(controller_api, "DEVICE")
 
-    assert gui._get_attribute_component(
-        [], "Table", AttrR(Table(structured_dtype=[("FIELD", uint32)]))
-    ) == SignalR(
-        name="Table",
-        read_pv="Table",
-        read_widget=TableRead(
-            widgets=[TextRead()] * 4 + [LED()] * 6 + [TextRead()] + [LED()] * 6
+    attribute_component = gui._get_attribute_component(
+        [],
+        "Table",
+        AttrR(
+            Table(
+                structured_dtype=[
+                    ("FIELD1", np.uint32),
+                    ("FIELD2", np.bool),
+                    ("FIELD3", np.dtype("S1000")),
+                ]
+            )
         ),
     )
+
+    assert isinstance(attribute_component, SignalR)
+    assert isinstance(attribute_component.read_widget, TableRead)
+    assert attribute_component.read_widget.widgets == [
+        TextRead(),
+        LED(),
+        TextRead(format=TextFormat.string),
+    ]


### PR DESCRIPTION
#Fixes #166
This PR adds `PvaEpicsGui`, which allows tables and prepends `pva://` to pvs to allow access to pva signals via the GUI. Tables already have this added, so this [issue](https://github.com/epics-containers/pvi/pull/147) in `pvi` should be merged. 