### PR TITLE
Add RBV signals to PVA transport

### DIFF
--- a/src/fastcs/transport/epics/pva/_pv_handlers.py
+++ b/src/fastcs/transport/epics/pva/_pv_handlers.py
@@ -13,6 +13,7 @@ from fastcs.datatypes import Table
 from .types import (
     MAJOR_ALARM_SEVERITY,
     RECORD_ALARM_STATUS,
+    T,
     cast_from_p4p_value,
     cast_to_p4p_value,
     make_p4p_type,
@@ -98,6 +99,55 @@ class CommandPvHandler:
                 op.done()
         else:
             raise RuntimeError("Commands should only take the value `True`.")
+
+
+def _make_shared_pv_arguments(
+    attribute: Attribute, initial_value: T
+) -> dict[str, object]:
+    type_ = make_p4p_type(attribute)
+    kwargs = {"initial": cast_to_p4p_value(attribute, initial_value)}
+    if isinstance(type_, (NTEnum | NTNDArray | NTTable)):
+        kwargs["nt"] = type_
+    else:
+
+        def _wrap(value: dict):
+            return Value(type_, value)
+
+        kwargs["wrap"] = _wrap
+
+    return kwargs
+
+
+def make_shared_read_pv(attribute: AttrR) -> SharedPV:
+    initial_value = attribute.get()
+
+    kwargs = _make_shared_pv_arguments(attribute, initial_value)
+
+    shared_pv = SharedPV(**kwargs)
+
+    async def on_update(value):
+        shared_pv.post(cast_to_p4p_value(attribute, value))
+
+    attribute.add_update_callback(on_update)
+
+    return shared_pv
+
+
+def make_shared_write_pv(attribute: AttrW) -> SharedPV:
+    initial_value = attribute.datatype.initial_value
+
+    kwargs = _make_shared_pv_arguments(attribute, initial_value)
+
+    kwargs["handler"] = WritePvHandler(attribute)
+
+    shared_pv = SharedPV(**kwargs)
+
+    async def async_write_display(value):
+        shared_pv.post(cast_to_p4p_value(attribute, value))
+
+    attribute.add_write_display_callback(async_write_display)
+
+    return shared_pv
 
 
 def make_shared_pv(attribute: Attribute) -> SharedPV:

--- a/src/fastcs/transport/epics/pva/ioc.py
+++ b/src/fastcs/transport/epics/pva/ioc.py
@@ -6,7 +6,11 @@ from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW
 from fastcs.controller_api import ControllerAPI
 from fastcs.util import snake_to_pascal
 
-from ._pv_handlers import make_command_pv, make_shared_pv
+from ._pv_handlers import (
+    make_command_pv,
+    make_shared_read_pv,
+    make_shared_write_pv,
+)
 from .pvi_tree import AccessModeType, PviTree
 
 
@@ -42,9 +46,21 @@ async def parse_attributes(
 
         for attr_name, attribute in controller_api.attributes.items():
             pv_name = get_pv_name(pv_prefix, attr_name)
-            attribute_pv = make_shared_pv(attribute)
-            provider.add(pv_name, attribute_pv)
-            pvi_tree.add_signal(pv_name, _attribute_to_access(attribute))
+            match attribute:
+                case AttrRW():
+                    attribute_pv = make_shared_write_pv(attribute)
+                    attribute_pv_rbv = make_shared_read_pv(attribute)
+                    provider.add(pv_name, attribute_pv)
+                    provider.add(f"{pv_name}_RBV", attribute_pv_rbv)
+                    pvi_tree.add_signal(pv_name, "rw")
+                case AttrR():
+                    attribute_pv = make_shared_read_pv(attribute)
+                    provider.add(pv_name, attribute_pv)
+                    pvi_tree.add_signal(pv_name, "r")
+                case AttrW():
+                    attribute_pv_rbv = make_shared_write_pv(attribute)
+                    provider.add(f"{pv_name}_RBV", attribute_pv_rbv)
+                    pvi_tree.add_signal(pv_name, "w")
 
         for attr_name, method in controller_api.command_methods.items():
             pv_name = get_pv_name(pv_prefix, attr_name)


### PR DESCRIPTION
Fixes #153 

This PR splits out `make_shared_pv` for read and write signals, creating two shared PV instances for `AttrRW`, where one is a `_RBV`.