### PR TITLE
Use SimpleHandler on AttrRW only

### DIFF
--- a/src/fastcs/attributes.py
+++ b/src/fastcs/attributes.py
@@ -49,9 +49,11 @@ class AttrHandlerRW(AttrHandlerR, AttrHandlerW):
 class SimpleAttrHandler(AttrHandlerRW):
     """Handler for internal parameters"""
 
-    async def put(self, attr: AttrRW[T], value: T) -> None:  # type: ignore
-        await attr.set(value)
+    async def put(self, attr: AttrW[T], value: T) -> None:
         await attr.update_display_without_process(value)
+
+        if isinstance(attr, AttrRW):
+            await attr.set(value)
 
     async def update(self, attr: AttrR) -> None:
         raise RuntimeError("SimpleHandler cannot update")

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -3,7 +3,14 @@ from functools import partial
 import pytest
 from pytest_mock import MockerFixture
 
-from fastcs.attributes import AttrHandlerR, AttrHandlerRW, AttrR, AttrRW, AttrW
+from fastcs.attributes import (
+    AttrHandlerR,
+    AttrHandlerRW,
+    AttrHandlerW,
+    AttrR,
+    AttrRW,
+    AttrW,
+)
 from fastcs.datatypes import Int, String
 
 
@@ -35,28 +42,22 @@ async def test_attributes():
 
 
 @pytest.mark.asyncio
-async def test_simple_handler_w(mocker: MockerFixture):
-    attr = AttrW(Int())
-    update_display_mock = mocker.patch.object(attr, "update_display_without_process")
+async def test_simple_handler_rw(mocker: MockerFixture):
+    attr = AttrRW(Int())
 
+    attr.update_display_without_process = mocker.MagicMock(
+        wraps=attr.update_display_without_process
+    )
+    attr.set = mocker.MagicMock(wraps=attr.set)
+
+    assert attr.sender
     # This is called by the transport when it receives a put
     await attr.sender.put(attr, 1)
 
-    # The callback to update the transport display should be called
-    update_display_mock.assert_called_once_with(1)
-
-
-@pytest.mark.asyncio
-async def test_simple_handler_rw(mocker: MockerFixture):
-    attr = AttrRW(Int())
-    update_display_mock = mocker.patch.object(attr, "update_display_without_process")
-    set_mock = mocker.patch.object(attr, "set")
-
-    await attr.sender.put(attr, 1)
-
-    update_display_mock.assert_called_once_with(1)
     # The Sender of the attribute should just set the value on the attribute
-    set_mock.assert_awaited_once_with(1)
+    attr.update_display_without_process.assert_called_once_with(1)
+    attr.set.assert_called_once_with(1)
+    assert attr.get() == 1
 
 
 class SimpleUpdater(AttrHandlerR):

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -6,7 +6,6 @@ from pytest_mock import MockerFixture
 from fastcs.attributes import (
     AttrHandlerR,
     AttrHandlerRW,
-    AttrHandlerW,
     AttrR,
     AttrRW,
     AttrW,


### PR DESCRIPTION
fixes #126 

This removes use of `SimpleHandler` from `AttrW` and defaults it in `AttrRW`. Testing `AttrW` with this handler has been removed, and testing with `AttrRW` amended to check we can read the value we set.