### PR TITLE
Add softioc functions to ca context

### DIFF
--- a/src/fastcs/transport/epics/ca/adapter.py
+++ b/src/fastcs/transport/epics/ca/adapter.py
@@ -1,4 +1,7 @@
 import asyncio
+from typing import Any
+
+from softioc import softioc
 
 from fastcs.controller_api import ControllerAPI
 from fastcs.transport.adapter import TransportAdapter
@@ -40,3 +43,11 @@ class EpicsCATransport(TransportAdapter):
     async def serve(self) -> None:
         print(f"Running FastCS IOC: {self._pv_prefix}")
         self._ioc.run(self._loop)
+
+    @property
+    def context(self) -> dict[str, Any]:
+        return {
+            command_name: getattr(softioc, command_name)
+            for command_name in softioc.command_names
+            if command_name != "exit"
+        }

--- a/tests/transport/epics/ca/test_softioc.py
+++ b/tests/transport/epics/ca/test_softioc.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy as np
 import pytest
 from pytest_mock import MockerFixture
+from softioc import softioc
 from tests.assertable_controller import (
     AssertableControllerAPI,
     MyTestController,
@@ -19,6 +20,7 @@ from fastcs.controller_api import ControllerAPI
 from fastcs.cs_methods import Command
 from fastcs.datatypes import Bool, Enum, Float, Int, String, Waveform
 from fastcs.exceptions import FastCSException
+from fastcs.transport.epics.ca.adapter import EpicsCATransport
 from fastcs.transport.epics.ca.ioc import (
     EPICS_MAX_NAME_LENGTH,
     EpicsCAIOC,
@@ -559,3 +561,15 @@ def test_update_datatype(mocker: MockerFixture):
         match="Attribute datatype must be of type <class 'fastcs.datatypes.Int'>",
     ):
         attr_w.update_datatype(String())  # type: ignore
+
+
+def test_ca_context_contains_softioc_commands(mocker: MockerFixture):
+    transport = EpicsCATransport(mocker.MagicMock(), mocker.MagicMock())
+
+    softioc_commands = {
+        command: getattr(softioc, command) for command in softioc.command_names
+    }
+    # We exclude "exit" from the context
+    softioc_commands.pop("exit")
+
+    assert transport.context == softioc_commands


### PR DESCRIPTION
fixes #190 

This PR adds softioc commands to the ca transport context, allowing us to run commands like `dbl` etc.