### PR TITLE
[WIP] Add transport extras

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,5 +42,5 @@
     // Mount the parent as /workspaces so we can pip install peers as editable
     "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
     // After the container is created, install the python project in editable form
-    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e '.[dev]' && pre-commit install"
+    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e '.[dev,all]' && pre-commit install"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,6 @@ dependencies = [
     "fastapi[standard]",
     "numpy",
     "pydantic",
-    "pvi~=0.11.0",
-    "pytango",
-    "softioc>=4.5.0",
-    "strawberry-graphql",
-    "p4p",
     "IPython",
 ]
 dynamic = ["version"]
@@ -30,6 +25,17 @@ readme = "README.md"
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
+all = [
+    "fastapi[standard]",
+    "numpy",
+    "p4p",
+    "pvi~=0.11.0",
+    "pydantic",
+    "pytango",
+    "softioc>=4.5.0",
+    "strawberry-graphql",
+    "uvicorn[standard]>=0.12.0",
+]
 dev = [
     "copier",
     "myst-parser",
@@ -50,15 +56,17 @@ dev = [
     "sphinx-design",
     "tox-direct",
     "types-mock",
-    "setuptools>=70.1", # https://github.com/DiamondLightSource/aioca/issues/71
+    "setuptools>=70.1",          # https://github.com/DiamondLightSource/aioca/issues/71
     "aioca",
     "p4p",
     "httpx",
     "tickit~=0.4.3",
 ]
-demo = [
-    "tickit~=0.4.3",
-]
+demo = ["tickit~=0.4.3"]
+epics = ["p4p", "pvi~=0.11.0", "pydantic", "softioc>=4.5.0"]
+tango = ["pytango"]
+graphql = ["strawberry-graphql", "uvicorn[standard]>=0.12.0"]
+rest = ["fastapi[standard]", "numpy", "pydantic", "uvicorn[standard]>=0.12.0"]
 
 [project.scripts]
 fastcs-demo = "fastcs.demo.__main__:main"


### PR DESCRIPTION
**Do not merge**

This PR addresses #94 

- [x] Add `epics`, `tango`, `graphql`, `rest`, `all` extras
- [ ] Make test suite work with "incomplete" installs, or add all transports to `dev`
