### PR TITLE
Redesign attribute callbacks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,8 @@ nitpick_ignore = [
     ("py:class", "p4p.nt.ndarray.NTNDArray"),
     ("py:class", "p4p.nt.NTTable"),
     # Problems in FastCS itself
+    ("py:class", "T"),
+    ("py:class", "AttrIOUpdateCallback"),
     ("py:class", "fastcs.transport.epics.pva.pvi_tree._PviSignalInfo"),
     ("py:class", "fastcs.logging._logging.LogLevel"),
     ("py:class", "fastcs.logging._graylog.GraylogEndpoint"),
@@ -102,6 +104,7 @@ nitpick_ignore = [
 ]
 nitpick_ignore_regex = [
     ("py:class", "fastcs.*.T"),
+    ("py:obj", "fastcs.*.T"),
     (r"py:.*", r"fastcs\.demo.*"),
     (r"py:.*", r"tickit.*"),
 ]

--- a/docs/snippets/dynamic.py
+++ b/docs/snippets/dynamic.py
@@ -79,7 +79,7 @@ class TemperatureControllerAttributeIO(
         response = await self._connection.send_query(f"{query}\r\n")
         value = response.strip("\r\n")
 
-        await attr.set(attr.dtype(value))
+        await attr.update(attr.dtype(value))
 
     async def send(
         self, attr: AttrW[NumberT, TemperatureControllerAttributeIORef], value: NumberT

--- a/docs/snippets/static07.py
+++ b/docs/snippets/static07.py
@@ -30,7 +30,7 @@ class IDAttributeIO(AttributeIO[NumberT, IDAttributeIORef]):
         response = await self._connection.send_query("ID?\r\n")
         value = response.strip("\r\n")
 
-        await attr.set(attr.dtype(value))
+        await attr.update(attr.dtype(value))
 
 
 class TemperatureController(Controller):

--- a/docs/snippets/static08.py
+++ b/docs/snippets/static08.py
@@ -35,7 +35,7 @@ class TemperatureControllerAttributeIO(
         response = await self._connection.send_query(f"{query}\r\n")
         value = response.strip("\r\n")
 
-        await attr.set(attr.dtype(value))
+        await attr.update(attr.dtype(value))
 
 
 class TemperatureController(Controller):

--- a/docs/snippets/static09.py
+++ b/docs/snippets/static09.py
@@ -35,7 +35,7 @@ class TemperatureControllerAttributeIO(
         response = await self._connection.send_query(f"{query}\r\n")
         value = response.strip("\r\n")
 
-        await attr.set(attr.dtype(value))
+        await attr.update(attr.dtype(value))
 
     async def send(
         self, attr: AttrW[NumberT, TemperatureControllerAttributeIORef], value: NumberT

--- a/docs/snippets/static10.py
+++ b/docs/snippets/static10.py
@@ -36,7 +36,7 @@ class TemperatureControllerAttributeIO(
         response = await self._connection.send_query(f"{query}\r\n")
         value = response.strip("\r\n")
 
-        await attr.set(attr.dtype(value))
+        await attr.update(attr.dtype(value))
 
     async def send(
         self, attr: AttrW[NumberT, TemperatureControllerAttributeIORef], value: NumberT

--- a/docs/snippets/static11.py
+++ b/docs/snippets/static11.py
@@ -37,7 +37,7 @@ class TemperatureControllerAttributeIO(
         response = await self._connection.send_query(f"{query}\r\n")
         value = response.strip("\r\n")
 
-        await attr.set(attr.dtype(value))
+        await attr.update(attr.dtype(value))
 
     async def send(
         self, attr: AttrW[NumberT, TemperatureControllerAttributeIORef], value: NumberT

--- a/docs/snippets/static12.py
+++ b/docs/snippets/static12.py
@@ -39,7 +39,7 @@ class TemperatureControllerAttributeIO(
         response = await self._connection.send_query(f"{query}\r\n")
         value = response.strip("\r\n")
 
-        await attr.set(attr.dtype(value))
+        await attr.update(attr.dtype(value))
 
     async def send(
         self, attr: AttrW[NumberT, TemperatureControllerAttributeIORef], value: NumberT
@@ -94,7 +94,7 @@ class TemperatureController(Controller):
             (await self._connection.send_query("V?\r\n")).strip("\r\n")
         )
         for index, controller in enumerate(self._ramp_controllers):
-            await controller.voltage.set(float(voltages[index]))
+            await controller.voltage.update(float(voltages[index]))
 
 
 gui_options = EpicsGUIOptions(

--- a/docs/snippets/static13.py
+++ b/docs/snippets/static13.py
@@ -40,7 +40,7 @@ class TemperatureControllerAttributeIO(
         response = await self._connection.send_query(f"{query}\r\n")
         value = response.strip("\r\n")
 
-        await attr.set(attr.dtype(value))
+        await attr.update(attr.dtype(value))
 
     async def send(
         self, attr: AttrW[NumberT, TemperatureControllerAttributeIORef], value: NumberT
@@ -95,12 +95,12 @@ class TemperatureController(Controller):
             (await self._connection.send_query("V?\r\n")).strip("\r\n")
         )
         for index, controller in enumerate(self._ramp_controllers):
-            await controller.voltage.set(float(voltages[index]))
+            await controller.voltage.update(float(voltages[index]))
 
     @command()
     async def disable_all(self) -> None:
         for rc in self._ramp_controllers:
-            await rc.enabled.process(OnOffEnum.Off)
+            await rc.enabled.put(OnOffEnum.Off, sync_setpoint=True)
             # TODO: The requests all get concatenated and the sim doesn't handle it
             await asyncio.sleep(0.1)
 

--- a/src/fastcs/attribute_io.py
+++ b/src/fastcs/attribute_io.py
@@ -1,7 +1,7 @@
 from typing import Any, Generic, cast, get_args
 
 from fastcs.attribute_io_ref import AttributeIORef, AttributeIORefT
-from fastcs.attributes import AttrR, AttrRW
+from fastcs.attributes import AttrR, AttrW
 from fastcs.datatypes import T
 from fastcs.tracer import Tracer
 
@@ -32,7 +32,7 @@ class AttributeIO(Generic[T, AttributeIORefT], Tracer):
     async def update(self, attr: AttrR[T, AttributeIORefT]) -> None:
         raise NotImplementedError()
 
-    async def send(self, attr: AttrRW[T, AttributeIORefT], value: T) -> None:
+    async def send(self, attr: AttrW[T, AttributeIORefT], value: T) -> None:
         raise NotImplementedError()
 
 

--- a/src/fastcs/attribute_io_ref.py
+++ b/src/fastcs/attribute_io_ref.py
@@ -20,5 +20,5 @@ class AttributeIORef:
 
 
 AttributeIORefT = TypeVar(
-    "AttributeIORefT", bound=AttributeIORef, default=AttributeIORef
+    "AttributeIORefT", bound=AttributeIORef, default=AttributeIORef, covariant=True
 )

--- a/src/fastcs/cs_methods.py
+++ b/src/fastcs/cs_methods.py
@@ -22,7 +22,7 @@ UnboundPutCallback = Callable[[Controller_T, Any], Coroutine[None, None, None]]
 CommandCallback = Callable[[], Coroutine[None, None, None]]
 """A Command callback that is bound and can be called without `self`"""
 ScanCallback = Callable[[], Coroutine[None, None, None]]
-"""A Scan callback that is bound and can be called withous `self`"""
+"""A Scan callback that is bound and can be called without `self`"""
 PutCallback = Callable[[Any], Coroutine[None, None, None]]
 """A Put callback that is bound and can be called without `self`"""
 

--- a/src/fastcs/datatypes.py
+++ b/src/fastcs/datatypes.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import enum
 from abc import abstractmethod
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Generic, TypeVar
@@ -22,10 +21,6 @@ T = TypeVar(
 )
 
 ATTRIBUTE_TYPES: tuple[type] = T.__constraints__  # type: ignore
-
-
-AttrSetCallback = Callable[[T], Awaitable[None]]
-AttrUpdateCallback = Callable[[], Awaitable[None]]
 
 
 @dataclass(frozen=True)

--- a/src/fastcs/demo/controllers.py
+++ b/src/fastcs/demo/controllers.py
@@ -62,7 +62,7 @@ class TemperatureControllerAttributeIO(
             response=response,
         )
 
-        await attr.set(attr.dtype(response))
+        await attr.update(attr.dtype(response))
 
 
 class TemperatureController(Controller):
@@ -87,7 +87,7 @@ class TemperatureController(Controller):
     @command()
     async def cancel_all(self) -> None:
         for rc in self._ramp_controllers:
-            await rc.enabled.process(OnOffEnum.Off)
+            await rc.enabled.put(OnOffEnum.Off, sync_setpoint=True)
             # TODO: The requests all get concatenated and the sim doesn't handle it
             await asyncio.sleep(0.1)
 
@@ -110,7 +110,7 @@ class TemperatureController(Controller):
                 query=query,
                 response=voltages,
             )
-            await controller.voltage.set(float(voltages[index]))
+            await controller.voltage.update(float(voltages[index]))
 
 
 class TemperatureRampController(Controller):

--- a/src/fastcs/transport/graphql/graphql.py
+++ b/src/fastcs/transport/graphql/graphql.py
@@ -124,7 +124,7 @@ def _wrap_attr_set(
     """Wrap an attribute in a function with annotations for strawberry"""
 
     async def _dynamic_f(value):
-        await attribute.process(value)
+        await attribute.put(value)
         return value
 
     # Add type annotations for validation, schema, conversions

--- a/src/fastcs/transport/rest/rest.py
+++ b/src/fastcs/transport/rest/rest.py
@@ -69,13 +69,13 @@ def _put_request_body(attribute: AttrW[T]):
 def _wrap_attr_put(
     attribute: AttrW[T],
 ) -> Callable[[T], Coroutine[Any, Any, None]]:
-    async def attr_set(request):
-        await attribute.process(cast_from_rest_type(attribute.datatype, request.value))
+    async def attr_put(request):
+        await attribute.put(cast_from_rest_type(attribute.datatype, request.value))
 
     # Fast api uses type annotations for validation, schema, conversions
-    attr_set.__annotations__["request"] = _put_request_body(attribute)
+    attr_put.__annotations__["request"] = _put_request_body(attribute)
 
-    return attr_set
+    return attr_put
 
 
 def _get_response_body(attribute: AttrR[T]):

--- a/src/fastcs/transport/tango/dsr.py
+++ b/src/fastcs/transport/tango/dsr.py
@@ -50,7 +50,7 @@ def _wrap_updater_fset(
 ) -> Callable[[Any, Any], Any]:
     async def fset(tango_device: Device, value):
         tango_device.info_stream(f"called fset method: {attr_name}")
-        coro = attribute.process(cast_from_tango_type(attribute.datatype, value))
+        coro = attribute.put(cast_from_tango_type(attribute.datatype, value))
         await _run_threadsafe_blocking(coro, loop)
 
     return fset

--- a/tests/assertable_controller.py
+++ b/tests/assertable_controller.py
@@ -7,7 +7,7 @@ from pytest_mock import MockerFixture, MockType
 
 from fastcs.attribute_io import AttributeIO
 from fastcs.attribute_io_ref import AttributeIORef
-from fastcs.attributes import AttrR, AttrW
+from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.controller import Controller
 from fastcs.controller_api import ControllerAPI
 from fastcs.datatypes import Int, T
@@ -26,6 +26,8 @@ class MyTestAttributeIO(AttributeIO[T, MyTestAttributeIORef]):
 
     async def send(self, attr: AttrW[T, MyTestAttributeIORef], value: T):
         print(f"sending {attr} = {value}")
+        if isinstance(attr, AttrRW):
+            await attr.update(value)
 
 
 test_attribute_io = MyTestAttributeIO()  # instance
@@ -96,13 +98,13 @@ class AssertableControllerAPI(ControllerAPI):
 
     @contextmanager
     def assert_write_here(self, path: list[str]):
-        yield from self._assert_method(path, "process")
+        yield from self._assert_method(path, "put")
 
     @contextmanager
     def assert_execute_here(self, path: list[str]):
         yield from self._assert_method(path, "")
 
-    def _assert_method(self, path: list[str], method: Literal["get", "process", ""]):
+    def _assert_method(self, path: list[str], method: Literal["get", "put", ""]):
         """
         This context manager can be used to confirm that a fastcs
         controller's respective attribute or command methods are called

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,8 @@ from softioc import builder
 from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.datatypes import Bool, Float, Int, String
 from fastcs.launch import build_controller_api
-from fastcs.logging import logger
+from fastcs.logging import configure_logging, logger
+from fastcs.logging._logging import LogLevel
 from fastcs.transport.tango.dsr import register_dev
 from tests.assertable_controller import MyTestAttributeIORef, MyTestController
 from tests.example_p4p_ioc import run as _run_p4p_ioc
@@ -87,11 +88,8 @@ def _run_ioc_as_subprocess(
     error_queue: multiprocessing.Queue,
     stdout_queue: multiprocessing.Queue,
 ):
-    # configure_logging(LogLevel.INFO)
-    # we need to capture log messages from transport
-    # logger = _logger.bind(logger_name="fastcs.transport.epics.ca.transport")
-    logger.add(print)  # forward log messages to stdout
-    logger.enable("fastcs")
+    configure_logging(LogLevel.TRACE)
+    logger.add(print)  # forward log messages to stdout for start up detection in tests
 
     try:
         from pytest_cov.embed import cleanup_on_sigterm

--- a/tests/example_p4p_ioc.py
+++ b/tests/example_p4p_ioc.py
@@ -41,13 +41,13 @@ class ChildController(Controller):
         print("D: RUNNING")
         await asyncio.sleep(0.1)
         print("D: FINISHED")
-        await self.j.set(self.j.get() + 1)
+        await self.j.update(self.j.get() + 1)
 
     e: AttrR = AttrR(Bool())
 
     @scan(1)
     async def flip_flop(self):
-        await self.e.set(not self.e.get())
+        await self.e.update(not self.e.get())
 
     f: AttrRW = AttrRW(Enum(FEnum))
     g: AttrRW = AttrRW(Waveform(np.int64, shape=(3,)))
@@ -63,13 +63,14 @@ class ChildController(Controller):
         else:
             self.fail_on_next_e = True
             print("I: FINISHED")
-            await self.j.set(self.j.get() + 1)
+            await self.j.update(self.j.get() + 1)
 
     j: AttrR = AttrR(Int())
 
 
 def run(pv_prefix="P4P_TEST_DEVICE"):
     controller = ParentController()
+    controller.a.enable_tracing()
     controller.child1 = ChildController(description="some sub controller")
     controller.child2 = ChildController(description="another sub controller")
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -182,8 +182,8 @@ def test_fastcs(controller):
     assert controller.initialised
     assert not controller.connected
 
-    # Controller Attributes with a Sender should have a _process_callback created
-    assert controller.read_write_int.has_process_callback()
+    # Controller Attributes with an IO _send_callback created
+    assert controller.read_write_int._on_put_callback is not None
 
     async def test_wrapper():
         loop.create_task(fastcs.serve_routines())
@@ -267,7 +267,7 @@ def test_update_periods():
     class AttributeIOTimesCalled(AttributeIO[int, AttributeIORefTimesCalled]):
         async def update(self, attr: AttrR[int, AttributeIORefTimesCalled]):
             attr.io_ref._times_called += 1
-            await attr.set(attr.io_ref._times_called)
+            await attr.update(attr.io_ref._times_called)
 
     class MyController(Controller):
         update_once = AttrR(Int(), io_ref=AttributeIORefTimesCalled(update_period=ONCE))

--- a/tests/transport/epics/ca/test_softioc.py
+++ b/tests/transport/epics/ca/test_softioc.py
@@ -51,7 +51,7 @@ async def test_create_and_link_read_pv(mocker: MockerFixture):
     record = make_record.return_value
 
     attribute = AttrR(Int())
-    attribute.add_set_callback = mocker.MagicMock()
+    attribute.add_on_update_callback = mocker.MagicMock()
 
     _create_and_link_read_pv("PREFIX", "PV", "attr", attribute)
 
@@ -59,8 +59,8 @@ async def test_create_and_link_read_pv(mocker: MockerFixture):
     add_attr_pvi_info.assert_called_once_with(record, "PREFIX", "attr", "r")
 
     # Extract the callback generated and set in the function and call it
-    attribute.add_set_callback.assert_called_once_with(mocker.ANY)
-    record_set_callback = attribute.add_set_callback.call_args[0][0]
+    attribute.add_on_update_callback.assert_called_once_with(mocker.ANY)
+    record_set_callback = attribute.add_on_update_callback.call_args[0][0]
     await record_set_callback(1)
 
     record.set.assert_called_once_with(1)
@@ -115,8 +115,8 @@ async def test_create_and_link_write_pv(mocker: MockerFixture):
     record = make_record.return_value
 
     attribute = AttrW(Int())
-    attribute.process_without_display_update = mocker.AsyncMock()
-    attribute.add_write_display_callback = mocker.MagicMock()
+    attribute.put = mocker.AsyncMock()
+    attribute.add_sync_setpoint_callback = mocker.MagicMock()
 
     _create_and_link_write_pv("PREFIX", "PV", "attr", attribute)
 
@@ -126,9 +126,9 @@ async def test_create_and_link_write_pv(mocker: MockerFixture):
     add_attr_pvi_info.assert_called_once_with(record, "PREFIX", "attr", "w")
 
     # Extract the write update callback generated and set in the function and call it
-    attribute.add_write_display_callback.assert_called_once_with(mocker.ANY)
-    write_display_callback = attribute.add_write_display_callback.call_args[0][0]
-    await write_display_callback(1)
+    attribute.add_sync_setpoint_callback.assert_called_once_with(mocker.ANY)
+    sync_setpoint_callback = attribute.add_sync_setpoint_callback.call_args[0][0]
+    await sync_setpoint_callback(1)
 
     record.set.assert_called_once_with(1, process=False)
 
@@ -136,7 +136,7 @@ async def test_create_and_link_write_pv(mocker: MockerFixture):
     on_update_callback = make_record.call_args[1]["on_update"]
     await on_update_callback(1)
 
-    attribute.process_without_display_update.assert_called_once_with(1)
+    attribute.put.assert_called_once_with(1)
 
 
 class LongEnum(enum.Enum):

--- a/tests/transport/rest/test_rest.py
+++ b/tests/transport/rest/test_rest.py
@@ -5,11 +5,7 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
-from tests.assertable_controller import (
-    AssertableControllerAPI,
-    MyTestAttributeIORef,
-    MyTestController,
-)
+from tests.assertable_controller import AssertableControllerAPI, MyTestController
 
 from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.controller_api import ControllerAPI
@@ -18,11 +14,11 @@ from fastcs.transport.rest.transport import RestTransport
 
 
 class RestController(MyTestController):
-    read_int = AttrR(Int(), io_ref=MyTestAttributeIORef())
-    read_write_int = AttrRW(Int(), io_ref=MyTestAttributeIORef())
+    read_int = AttrR(Int())
+    read_write_int = AttrRW(Int())
     read_write_float = AttrRW(Float())
     read_bool = AttrR(Bool())
-    write_bool = AttrW(Bool(), io_ref=MyTestAttributeIORef())
+    write_bool = AttrW(Bool())
     read_string = AttrRW(String())
     enum = AttrRW(Enum(enum.IntEnum("Enum", {"RED": 0, "GREEN": 1, "BLUE": 2})))
     one_d_waveform = AttrRW(Waveform(np.int32, (10,)))

--- a/tests/transport/tango/test_dsr.py
+++ b/tests/transport/tango/test_dsr.py
@@ -8,7 +8,6 @@ from tango import DeviceProxy, DevState
 from tango.test_context import DeviceTestContext
 from tests.assertable_controller import (
     AssertableControllerAPI,
-    MyTestAttributeIORef,
     MyTestController,
 )
 
@@ -31,11 +30,11 @@ def mock_run_threadsafe_blocking(module_mocker: MockerFixture):
 
 
 class TangoController(MyTestController):
-    read_int = AttrR(Int(), io_ref=MyTestAttributeIORef())
-    read_write_int = AttrRW(Int(), io_ref=MyTestAttributeIORef())
+    read_int = AttrR(Int())
+    read_write_int = AttrRW(Int())
     read_write_float = AttrRW(Float())
     read_bool = AttrR(Bool())
-    write_bool = AttrW(Bool(), io_ref=MyTestAttributeIORef())
+    write_bool = AttrW(Bool())
     read_string = AttrRW(String())
     enum = AttrRW(Enum(enum.IntEnum("Enum", {"RED": 0, "GREEN": 1, "BLUE": 2})))
     one_d_waveform = AttrRW(Waveform(np.int32, (10,)))


### PR DESCRIPTION
### Summary
- `AttrR.update` and `AttrR._on_update_callbacks` -> `AttrR._update_callback`
  - Used to create an async task called periodically to update the attribute
- `AttrR.set()` -> `AttrR.update()`
- `AttrW.process()` -> `AttrW.put(sync_setpoint: bool = False)`
  - Transports should call without `sync_setpoint`
- `AttrR._on_set_callbacks` -> `AttrR._on_update_callbacks`
  - Called when the value in the attribute is updated. This is what transports register with to get the latest value.
  - In an `AttrR` or `AttrRW` without an IO, this is left unset so `update` does nothing.
- `AttrW._process_callbacks` -> `AttrW._on_put_callback`. This is called when a new value is put.
  - Calls send on the IO if it has one
  - In an `AttrRW` without an IO, the on_put_callback falls back to `AttrRW.set` so that internal driver parameters work as expected. This replaces the old `SimpleHandler` in a much simple way.
- `AttrW._write_display_callbacks` -> `AttrW._sync_setpoint_callbacks`
  - Called in `put(sync_setpoint=True)` to update the setpoint of the attribute being put, e.g. when a driver is manually putting to attributes based on user input such as a fan out
  - Called in `AttrRW.update` the first time to initialise the setpoints so that they aren't blank
  
### Outstanding Questions
- ~~Should transports ever call put with sync_setpoint=True? This will update the setpoints of all transports. I think it is useful to not do this so that it is clear when looking at the UI for a transport that the put was from somewhere else.~~
- ~~Should fan out attributes call put with sync_setpoint=True? I think yes because it is effectively a user input and the UI should reflect that.~~
- ~~Do the callback names make sense? Should `on_put` just be `put`, or something else?~~