### PR TITLE
Log exceptions in failed scan tasks

### DIFF
--- a/src/fastcs/attributes/attr_r.py
+++ b/src/fastcs/attributes/attr_r.py
@@ -110,8 +110,8 @@ class AttrR(Attribute[DType_T, AttributeIORefT]):
             try:
                 self.log_event("Update attribute", topic=self)
                 await update_callback(self)
-            except Exception as e:
-                logger.opt(exception=e).error("Update loop failed", attribute=self)
+            except Exception:
+                logger.error("Attribute update loop stopped", attribute=self)
                 raise
 
         return update_attribute

--- a/src/fastcs/attributes/attr_w.py
+++ b/src/fastcs/attributes/attr_w.py
@@ -68,6 +68,8 @@ class AttrW(Attribute[DType_T, AttributeIORefT]):
                     "Sync setpoint failed", attribute=self, setpoint=setpoint
                 )
 
+        self.log_event("Put complete", setpoint=setpoint, attribute=self)
+
     async def _call_sync_setpoint_callbacks(self, setpoint: DType_T) -> None:
         if self._sync_setpoint_callbacks:
             await asyncio.gather(

--- a/src/fastcs/control_system.py
+++ b/src/fastcs/control_system.py
@@ -7,7 +7,6 @@ from typing import Any
 from IPython.terminal.embed import InteractiveShellEmbed
 
 from fastcs.controllers import BaseController, Controller
-from fastcs.exceptions import FastCSError
 from fastcs.logging import bind_logger
 from fastcs.methods import Command, Scan, ScanCallback
 from fastcs.tracer import Tracer
@@ -63,11 +62,8 @@ class FastCS:
     def _scan_done(self, task: asyncio.Task):
         try:
             task.result()
-        except Exception as e:
-            raise FastCSError(
-                "Exception raised in scan method of "
-                f"{self._controller.__class__.__name__}"
-            ) from e
+        except Exception:
+            logger.exception("Exception raised in scan task")
 
     def _stop_scan_tasks(self):
         for task in self._scan_tasks:

--- a/tests/test_control_system.py
+++ b/tests/test_control_system.py
@@ -7,7 +7,6 @@ from fastcs.attributes import AttributeIO, AttributeIORef, AttrR, AttrRW
 from fastcs.control_system import FastCS, build_controller_api
 from fastcs.controllers import Controller
 from fastcs.datatypes import Int
-from fastcs.exceptions import FastCSError
 from fastcs.methods import Command, command, scan
 from fastcs.util import ONCE
 
@@ -152,8 +151,6 @@ async def test_scan_raises_exception_via_callback():
     task = asyncio.create_task(fastcs.serve(interactive=False))
     # This allows scan time to run
     await asyncio.sleep(0.2)
-    # _scan_done should raise an exception
-    assert isinstance(exception_info["exception"], FastCSError)
     for task in fastcs._scan_tasks:
         internal_exception = task.exception()
         assert internal_exception


### PR DESCRIPTION
We now log only a single line in the attribute and scan update and re-raise to exit out of the update loop and rely on `_scan_done` to print a nice view of the stack trace when the exception propagates up.

Created #280 to improve this further and not stop all tasks of the same period when one fails.