### PR TITLE
Set AttrW after Put in pva transport

### DIFF
--- a/src/fastcs/transports/epics/pva/_pv_handlers.py
+++ b/src/fastcs/transports/epics/pva/_pv_handlers.py
@@ -47,15 +47,14 @@ class WritePvHandler:
         cast_value = cast_from_p4p_value(self._attr_w, raw_value)
 
         tracer.log_event("PV put", topic=self._attr_w, pv=pv, value=cast_value)
-        try:
-            await self._attr_w.put(cast_value)
-            op.done()
-        except Exception as e:
-            op.done(error=e)
+
         if isinstance(self._attr_w.datatype, Enum):
             pv.post(cast_to_p4p_value(self._attr_w, cast_value))
         else:
             pv.post(value)
+
+        await self._attr_w.put(cast_value)
+        op.done()
 
 
 class CommandPvHandler:


### PR DESCRIPTION
It was found that setting an `AttrRW` would update the `AttrR`, but not the `AttrW`. This was because we must now do:
```python
op.done()
pv.post(value)
```
However, it seems that the value you get for an `Enum` in `value = op.value()` is in the form `ntenum(3, TTLIN4.VAL)` (for example), which is correctly converted to the FastCS value `<Labels.TTLIN4.VAL: 4>` (for example), but a value in the form of:
```python
{
                "index": attribute.datatype.index_of(value),
                "choices": attribute.datatype.names,
            }
```
must be passed in the `pv.post()`. This has led to this addition:
```python
        if isinstance(self._attr_w.datatype, Enum):
            pv.post(cast_to_p4p_value(self._attr_w, cast_value))
        else:
            pv.post(value)
```
in order to cast the value to the write form.