### PR TITLE
Fix command buttons in pva transport

### DIFF
--- a/src/fastcs/transports/epics/gui.py
+++ b/src/fastcs/transports/epics/gui.py
@@ -44,6 +44,8 @@ logger = bind_logger(logger_name=__name__)
 class EpicsGUI:
     """For creating gui in the EPICS transports."""
 
+    command_value = "1"
+
     def __init__(self, controller_api: ControllerAPI, pv_prefix: str) -> None:
         self._controller_api = controller_api
         self._pv_prefix = pv_prefix
@@ -133,8 +135,7 @@ class EpicsGUI:
         return SignalX(
             name=name,
             write_pv=pv,
-            value="1",
-            write_widget=ButtonPanel(actions={name: "1"}),
+            write_widget=ButtonPanel(actions={name: self.command_value}),
         )
 
     def create_gui(self, options: EpicsGUIOptions | None = None) -> None:

--- a/src/fastcs/transports/epics/pva/gui.py
+++ b/src/fastcs/transports/epics/pva/gui.py
@@ -13,6 +13,8 @@ from fastcs.transports.epics.gui import EpicsGUI
 class PvaEpicsGUI(EpicsGUI):
     """For creating gui in the PVA EPICS transport."""
 
+    command_value = "true"
+
     def _get_pv(self, attr_path: list[str], name: str):
         return f"pva://{super()._get_pv(attr_path, name)}"
 

--- a/tests/transports/epics/ca/test_gui.py
+++ b/tests/transports/epics/ca/test_gui.py
@@ -23,8 +23,8 @@ from fastcs.transports import ControllerAPI
 from fastcs.transports.epics.gui import EpicsGUI
 
 
-def test_get_pv(controller_api):
-    gui = EpicsGUI(controller_api, "DEVICE")
+def test_get_pv():
+    gui = EpicsGUI(ControllerAPI(), "DEVICE")
 
     assert gui._get_pv([], "A") == "DEVICE:A"
     assert gui._get_pv(["B"], "C") == "DEVICE:B:C"
@@ -42,8 +42,8 @@ def test_get_pv(controller_api):
         # (Waveform(array_dtype=np.int32), None),
     ],
 )
-def test_get_attribute_component_r(datatype, widget, controller_api):
-    gui = EpicsGUI(controller_api, "DEVICE")
+def test_get_attribute_component_r(datatype, widget):
+    gui = EpicsGUI(ControllerAPI(), "DEVICE")
 
     assert gui._get_attribute_component([], "Attr", AttrR(datatype)) == SignalR(
         name="Attr", read_pv="Attr", read_widget=widget
@@ -60,16 +60,16 @@ def test_get_attribute_component_r(datatype, widget, controller_api):
         (Enum(ColourEnum), ComboBox(choices=["RED", "GREEN", "BLUE"])),
     ],
 )
-def test_get_attribute_component_w(datatype, widget, controller_api):
-    gui = EpicsGUI(controller_api, "DEVICE")
+def test_get_attribute_component_w(datatype, widget):
+    gui = EpicsGUI(ControllerAPI(), "DEVICE")
 
     assert gui._get_attribute_component([], "Attr", AttrW(datatype)) == SignalW(
         name="Attr", write_pv="Attr", write_widget=widget
     )
 
 
-def test_get_attribute_component_none(mocker, controller_api):
-    gui = EpicsGUI(controller_api, "DEVICE")
+def test_get_attribute_component_none(mocker):
+    gui = EpicsGUI(ControllerAPI(), "DEVICE")
 
     mocker.patch.object(gui, "_get_read_widget", return_value=None)
     mocker.patch.object(gui, "_get_write_widget", return_value=None)
@@ -78,13 +78,13 @@ def test_get_attribute_component_none(mocker, controller_api):
     assert gui._get_attribute_component([], "Attr", AttrRW(Int())) is None
 
 
-def test_get_read_widget_none(controller_api):
-    gui = EpicsGUI(controller_api, "DEVICE")
+def test_get_read_widget_none():
+    gui = EpicsGUI(ControllerAPI(), "DEVICE")
     assert gui._get_read_widget(fastcs_datatype=Waveform(np.int32)) is None
 
 
-def test_get_write_widget_none(controller_api):
-    gui = EpicsGUI(controller_api, "DEVICE")
+def test_get_write_widget_none():
+    gui = EpicsGUI(ControllerAPI(), "DEVICE")
     assert gui._get_write_widget(fastcs_datatype=Waveform(np.int32)) is None
 
 
@@ -164,3 +164,12 @@ def test_get_components_none(mocker):
     components = gui.extract_api_components(controller_api)
 
     assert components == []
+
+
+def test_get_command_component():
+    gui = EpicsGUI(ControllerAPI(), "DEVICE")
+
+    component = gui._get_command_component([], "Command")
+
+    assert isinstance(component, SignalX)
+    assert component.write_widget == ButtonPanel(actions={"Command": "1"})

--- a/tests/transports/epics/pva/test_pva_gui.py
+++ b/tests/transports/epics/pva/test_pva_gui.py
@@ -1,9 +1,11 @@
 import numpy as np
 from pvi.device import (
     LED,
+    ButtonPanel,
     CheckBox,
     SignalR,
     SignalW,
+    SignalX,
     TableRead,
     TableWrite,
     TextFormat,
@@ -13,19 +15,20 @@ from pvi.device import (
 
 from fastcs.attributes import AttrR, AttrW
 from fastcs.datatypes import Table
+from fastcs.transports import ControllerAPI
 from fastcs.transports.epics.pva.gui import PvaEpicsGUI
 
 
-def test_get_pv_in_pva(controller_api):
-    gui = PvaEpicsGUI(controller_api, "DEVICE")
+def test_get_pv_in_pva():
+    gui = PvaEpicsGUI(ControllerAPI(), "DEVICE")
 
     assert gui._get_pv([], "A") == "pva://DEVICE:A"
     assert gui._get_pv(["B"], "C") == "pva://DEVICE:B:C"
     assert gui._get_pv(["D", "E"], "F") == "pva://DEVICE:D:E:F"
 
 
-def test_get_attribute_component_table_write(controller_api):
-    gui = PvaEpicsGUI(controller_api, "DEVICE")
+def test_get_attribute_component_table_write():
+    gui = PvaEpicsGUI(ControllerAPI(), "DEVICE")
 
     attribute_component = gui._get_attribute_component(
         [],
@@ -50,8 +53,8 @@ def test_get_attribute_component_table_write(controller_api):
     ]
 
 
-def test_get_attribute_component_table_read(controller_api):
-    gui = PvaEpicsGUI(controller_api, "DEVICE")
+def test_get_attribute_component_table_read():
+    gui = PvaEpicsGUI(ControllerAPI(), "DEVICE")
 
     attribute_component = gui._get_attribute_component(
         [],
@@ -74,3 +77,12 @@ def test_get_attribute_component_table_read(controller_api):
         LED(),
         TextRead(format=TextFormat.string),
     ]
+
+
+def test_get_command_component():
+    gui = PvaEpicsGUI(ControllerAPI(), "DEVICE")
+
+    component = gui._get_command_component([], "Command")
+
+    assert isinstance(component, SignalX)
+    assert component.write_widget == ButtonPanel(actions={"Command": "true"})


### PR DESCRIPTION
The pva transport expects the value for commands to be a boolean, while the ca transports expects it to be an int.