### PR TITLE
Fix EPICA CA string truncation

### DIFF
--- a/src/fastcs/transports/epics/ca/util.py
+++ b/src/fastcs/transports/epics/ca/util.py
@@ -83,7 +83,9 @@ def _make_in_record(pv: str, attribute: AttrR) -> RecordWrapper:
         case String():
             record = builder.longStringIn(
                 pv,
-                length=attribute.datatype.length or DEFAULT_STRING_WAVEFORM_LENGTH,
+                length=(attribute.datatype.length + 1)
+                if attribute.datatype.length
+                else DEFAULT_STRING_WAVEFORM_LENGTH + 1,
                 **common_fields,
             )
         case Enum():
@@ -157,7 +159,9 @@ def _make_out_record(pv: str, attribute: AttrW, on_update: Callable) -> RecordWr
         case String():
             record = builder.longStringOut(
                 pv,
-                length=attribute.datatype.length or DEFAULT_STRING_WAVEFORM_LENGTH,
+                length=(attribute.datatype.length + 1)
+                if attribute.datatype.length
+                else DEFAULT_STRING_WAVEFORM_LENGTH + 1,
                 **common_fields,
             )
         case Enum():

--- a/tests/transports/epics/ca/test_softioc.py
+++ b/tests/transports/epics/ca/test_softioc.py
@@ -72,7 +72,12 @@ async def test_create_and_link_read_pv(mocker: MockerFixture):
         (
             AttrR(String()),
             "longStringIn",
-            {"length": 256, "DESC": None, "initial_value": ""},
+            {"length": 257, "DESC": None, "initial_value": ""},
+        ),
+        (
+            AttrR(String(length=10)),
+            "longStringIn",
+            {"length": 11, "DESC": None, "initial_value": ""},
         ),
         (
             AttrR(Enum(ColourEnum)),
@@ -196,6 +201,16 @@ class LongEnum(enum.Enum):
                 "DESC": None,
                 "initial_value": 0,
             },
+        ),
+        (
+            AttrW(String()),
+            "longStringOut",
+            {"length": 257, "DESC": None, "initial_value": ""},
+        ),
+        (
+            AttrW(String(length=10)),
+            "longStringOut",
+            {"length": 11, "DESC": None, "initial_value": ""},
         ),
     ),
 )


### PR DESCRIPTION
This accounts for a null terminator at the end of the string in the record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted string length handling so string fields reserve an extra byte for proper formatting and transmission.
* **Tests**
  * Updated test expectations to reflect the increased string length in read/write record validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->