### PR TITLE
Simplify event loop handling and remove deprecated get_event_loop

### DIFF
--- a/docs/explanations/control_system.md
+++ b/docs/explanations/control_system.md
@@ -1,0 +1,86 @@
+# The FastCS class
+
+`FastCS` is the entrypoint for a fastcs application. It connects a `Controller` to one
+or more `Transport`s, runs the controller's update loops as background tasks, and
+manages the full application lifecycle from startup to shutdown.
+
+## Construction
+
+```python
+from fastcs import FastCS
+from fastcs.controllers import Controller
+from fastcs.transports.epics import EpicsCATransport
+
+
+class MyController(Controller):
+    pass
+
+
+control_system = FastCS(controller=MyController(), transports=[EpicsCATransport()])
+
+control_system.run()
+```
+
+## Startup and Runtime
+
+Calling `control_system.run()` (or `await control_system.serve()`) executes the
+following steps in order:
+
+1. **Initialise the controller:** `controller.initialise()` is awaited, allowing the
+   controller to query the device and dynamically add attributes before the API is
+   built. After that, `controller.post_initialise()` is called to perform any final
+   setup, such as validating all type hints are satisfied.
+
+2. **Build the API:** `controller.create_api_and_tasks()` returns the `ControllerAPI`
+   that transports will use, plus two lists of coroutines: *initial tasks* (run once at
+   startup) and *scan tasks* (run as continuous background loops).
+
+3. **Connect transports:** each transport's `connect()` method is called with the
+   `ControllerAPI`. This lets the transport inspect the controller's attributes and
+   commands to prepare its protocol-specific representations before serving begins.
+
+4. **Connect the controller:** `controller.connect()` is called to open the connection
+   to the device and perform any other setup logic.
+
+5. **Run initial tasks:** each initial-task coroutine is awaited in sequence. These are
+   `@scan(period=ONCE)` methods and `AttributeIO` update callbacks with
+   `update_period=ONCE`.
+
+6. **Start scan tasks:** each scan task coroutine is wrapped in an `asyncio.Task` and
+   run as a background task for the lifetime of the application.
+
+7. **Gather transport coroutines:** `asyncio.gather` runs all transport `serve()`
+   coroutines concurrently. Each transport begins accepting and responding to protocol
+   requests.
+
+8. **Scan pause and reconnect**: If any scan tasks raise exceptions, all scan tasks are
+   paused until `reconnect`.
+
+## The Interactive Shell
+
+Alongside the transport coroutines, FastCS launches an embedded
+[IPython](https://ipython.org/) shell (unless `interactive=False` is passed). The shell
+namespace is pre-populated with:
+
+| Name | Value |
+|------|-------|
+| `controller` | The root controller instance |
+| `transports` | The class names of active transports |
+| `run` | A helper that schedules a coroutine on the FastCS event loop from the IPython thread |
+| *transport-specific keys* | Any entries exposed via each transport's `context` property |
+
+The shell runs in a separate thread so it does not block the asyncio event loop. When
+the user exits the shell, the application begins its shutdown sequence.
+
+When `interactive=False` a simple coroutine that blocks forever keeps the application
+alive until the task is cancelled externally (e.g. SIGINT).
+
+## Shutdown Sequence
+
+When then application is stopped, FastCS performs an orderly teardown:
+
+1. **Cancel scan tasks:** each background scan task is cancelled and removed, stopping
+   all periodic polling.
+
+2. **Disconnect the controller:** `controller.disconnect()` is awaited, allowing the
+   controller to release device resources cleanly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ addopts = """
     --tb=native -vv --doctest-modules --doctest-glob="*.md" --ignore-glob docs/snippets/*py --benchmark-sort=mean --benchmark-columns="mean, min, max, outliers, ops, rounds"
     """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
-# https://github.com/DiamondLightSource/FastCS/issues/230
 filterwarnings = "error"
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"

--- a/src/fastcs/control_system.py
+++ b/src/fastcs/control_system.py
@@ -28,15 +28,9 @@ class FastCS:
         loop: Optional event loop to run the control system in
     """
 
-    def __init__(
-        self,
-        controller: Controller,
-        transports: Sequence[Transport],
-        loop: asyncio.AbstractEventLoop | None = None,
-    ):
+    def __init__(self, controller: Controller, transports: Sequence[Transport]):
         self._controller = controller
         self._transports = transports
-        self._loop = loop or asyncio.get_event_loop()
 
         self._scan_coros: list[ScanCallback] = []
         self._initial_coros: list[ScanCallback] = []
@@ -47,36 +41,25 @@ class FastCS:
         """Run the application
 
         This is a convenience method to call `serve` in a synchronous context.
+        To use in an async context, call `serve` directly.
 
         Args:
             interactive: Whether to create an interactive IPython shell
 
         """
-        serve = asyncio.ensure_future(self.serve(interactive=interactive))
 
-        if os.name != "nt":
-            self._loop.add_signal_handler(signal.SIGINT, serve.cancel)
-            self._loop.add_signal_handler(signal.SIGTERM, serve.cancel)
-        self._loop.run_until_complete(serve)
+        async def _serve():
+            """Wrapper to add signal handlers and call `serve`"""
+            loop = asyncio.get_running_loop()
+            task = asyncio.current_task()
 
-    async def _run_initial_coros(self):
-        for coro in self._initial_coros:
-            await coro()
+            if os.name != "nt" and task is not None:
+                loop.add_signal_handler(signal.SIGINT, task.cancel)
+                loop.add_signal_handler(signal.SIGTERM, task.cancel)
 
-    async def _start_scan_tasks(self):
-        self._scan_tasks = {self._loop.create_task(coro()) for coro in self._scan_coros}
+            await self.serve(interactive=interactive)
 
-    def _stop_scan_tasks(self):
-        for task in self._scan_tasks:
-            if not task.done():
-                try:
-                    task.cancel()
-                except (asyncio.CancelledError, RuntimeError):
-                    pass
-                except Exception as e:
-                    raise RuntimeError("Unhandled exception in stop scan tasks") from e
-
-        self._scan_tasks.clear()
+        asyncio.run(_serve())
 
     async def serve(self, interactive: bool = True) -> None:
         """Serve the control system over the given transports on the current event loop
@@ -110,7 +93,7 @@ class FastCS:
 
         coros: list[Coroutine] = []
         for transport in self._transports:
-            transport.connect(controller_api=self.controller_api, loop=self._loop)
+            transport.connect(controller_api=self.controller_api)
             coros.append(transport.serve())
             common_context = context.keys() & transport.context.keys()
             if common_context:
@@ -153,16 +136,30 @@ class FastCS:
             self._stop_scan_tasks()
             await self._controller.disconnect()
 
+    async def _run_initial_coros(self):
+        for coro in self._initial_coros:
+            await coro()
+
+    async def _start_scan_tasks(self):
+        self._scan_tasks = {asyncio.create_task(coro()) for coro in self._scan_coros}
+
     async def _interactive_shell(self, context: dict[str, Any]):
         """Spawn interactive shell in another thread and wait for it to complete."""
+        loop = asyncio.get_running_loop()
 
         def run(coro: Coroutine[None, None, None]):
             """Run coroutine on FastCS event loop from IPython thread."""
 
             def wrapper():
-                asyncio.create_task(coro)
+                task = asyncio.create_task(coro)
 
-            self._loop.call_soon_threadsafe(wrapper)
+                def _log_exception(t: asyncio.Task):
+                    if not t.cancelled() and (exc := t.exception()):
+                        logger.exception("`run` task raised exception", exc_info=exc)
+
+                task.add_done_callback(_log_exception)
+
+            loop.call_soon_threadsafe(wrapper)
 
         async def interactive_shell(
             context: dict[str, object], stop_event: asyncio.Event
@@ -176,8 +173,24 @@ class FastCS:
         context["run"] = run
 
         stop_event = asyncio.Event()
-        self._loop.create_task(interactive_shell(context, stop_event))
+        shell_task = asyncio.create_task(interactive_shell(context, stop_event))
+
         await stop_event.wait()
+
+        if not shell_task.cancelled() and (exc := shell_task.exception()):
+            logger.exception("Interactive shell raised exception", exc_info=exc)
+
+    def _stop_scan_tasks(self):
+        for task in self._scan_tasks:
+            if not task.done():
+                try:
+                    task.cancel()
+                except (asyncio.CancelledError, RuntimeError):
+                    pass
+                except Exception as e:
+                    raise RuntimeError("Unhandled exception in stop scan tasks") from e
+
+        self._scan_tasks.clear()
 
     def __del__(self):
         self._stop_scan_tasks()

--- a/src/fastcs/launch.py
+++ b/src/fastcs/launch.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 import json
 from pathlib import Path
@@ -158,9 +157,7 @@ def _launch(
         else:
             controller = controller_class()
 
-        instance = FastCS(
-            controller, instance_options.transport, loop=asyncio.get_event_loop()
-        )
+        instance = FastCS(controller, instance_options.transport)
 
         instance.run()
 

--- a/src/fastcs/transports/epics/ca/ioc.py
+++ b/src/fastcs/transports/epics/ca/ioc.py
@@ -41,11 +41,8 @@ class EpicsCAIOC:
         _create_and_link_attribute_pvs(pv_prefix, controller_api)
         _create_and_link_command_pvs(pv_prefix, controller_api)
 
-    def run(
-        self,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        dispatcher = AsyncioDispatcher(loop)  # Needs running loop
+    def run(self) -> None:
+        dispatcher = AsyncioDispatcher(asyncio.get_running_loop())
         builder.LoadDatabase()
         softioc.iocInit(dispatcher)
 

--- a/src/fastcs/transports/epics/ca/transport.py
+++ b/src/fastcs/transports/epics/ca/transport.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -28,13 +27,8 @@ class EpicsCATransport(Transport):
     gui: EpicsGUIOptions | None = None
     """Options for the GUI. If not set, no GUI will be created."""
 
-    def connect(
-        self,
-        controller_api: ControllerAPI,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
+    def connect(self, controller_api: ControllerAPI) -> None:
         self._controller_api = controller_api
-        self._loop = loop
         self._pv_prefix = self.epicsca.pv_prefix
         self._ioc = EpicsCAIOC(self.epicsca.pv_prefix, controller_api)
 
@@ -47,7 +41,7 @@ class EpicsCATransport(Transport):
     async def serve(self) -> None:
         """Serve `ControllerAPI` over EPICS Channel Access"""
         logger.info("Running IOC", pv_prefix=self._pv_prefix)
-        self._ioc.run(self._loop)
+        self._ioc.run()
 
     @property
     def context(self) -> dict[str, Any]:

--- a/src/fastcs/transports/epics/pva/transport.py
+++ b/src/fastcs/transports/epics/pva/transport.py
@@ -1,13 +1,8 @@
-import asyncio
 from dataclasses import dataclass, field
 
 from fastcs.controllers import ControllerAPI
 from fastcs.logging import logger
-from fastcs.transports.epics import (
-    EpicsDocsOptions,
-    EpicsGUIOptions,
-    EpicsIOCOptions,
-)
+from fastcs.transports.epics import EpicsDocsOptions, EpicsGUIOptions, EpicsIOCOptions
 from fastcs.transports.epics.docs import EpicsDocs
 from fastcs.transports.epics.pva.gui import PvaEpicsGUI
 from fastcs.transports.transport import Transport
@@ -23,11 +18,7 @@ class EpicsPVATransport(Transport):
     docs: EpicsDocsOptions | None = None
     gui: EpicsGUIOptions | None = None
 
-    def connect(
-        self,
-        controller_api: ControllerAPI,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
+    def connect(self, controller_api: ControllerAPI) -> None:
         self._controller_api = controller_api
         self._pv_prefix = self.epicspva.pv_prefix
         self._ioc = P4PIOC(self.epicspva.pv_prefix, controller_api)

--- a/src/fastcs/transports/graphql/transport.py
+++ b/src/fastcs/transports/graphql/transport.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass, field
 
 from fastcs.controllers import ControllerAPI
@@ -14,11 +13,7 @@ class GraphQLTransport(Transport):
 
     graphql: GraphQLServerOptions = field(default_factory=GraphQLServerOptions)
 
-    def connect(
-        self,
-        controller_api: ControllerAPI,
-        loop: asyncio.AbstractEventLoop,
-    ):
+    def connect(self, controller_api: ControllerAPI):
         self._server = GraphQLServer(controller_api)
 
     async def serve(self) -> None:

--- a/src/fastcs/transports/rest/transport.py
+++ b/src/fastcs/transports/rest/transport.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass, field
 
 from fastcs.controllers import ControllerAPI
@@ -14,11 +13,7 @@ class RestTransport(Transport):
 
     rest: RestServerOptions = field(default_factory=RestServerOptions)
 
-    def connect(
-        self,
-        controller_api: ControllerAPI,
-        loop: asyncio.AbstractEventLoop,
-    ):
+    def connect(self, controller_api: ControllerAPI):
         self._server = RestServer(controller_api)
 
     async def serve(self) -> None:

--- a/src/fastcs/transports/tango/transport.py
+++ b/src/fastcs/transports/tango/transport.py
@@ -13,13 +13,9 @@ class TangoTransport(Transport):
 
     tango: TangoDSROptions = field(default_factory=TangoDSROptions)
 
-    def connect(
-        self,
-        controller_api: ControllerAPI,
-        loop: asyncio.AbstractEventLoop,
-    ):
-        self._dsr = TangoDSR(controller_api, loop)
+    def connect(self, controller_api: ControllerAPI):
+        self._controller_api = controller_api
 
     async def serve(self) -> None:
-        coro = asyncio.to_thread(self._dsr.run, self.tango)
-        await coro
+        self._dsr = TangoDSR(self._controller_api, asyncio.get_running_loop())
+        await asyncio.to_thread(self._dsr.run, self.tango)

--- a/src/fastcs/transports/transport.py
+++ b/src/fastcs/transports/transport.py
@@ -1,4 +1,3 @@
-import asyncio
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, ClassVar, Union
@@ -8,8 +7,7 @@ from fastcs.controllers import ControllerAPI
 
 @dataclass
 class Transport:
-    """A base class for transport's implementation
-    so it can be used in FastCS."""
+    """A base class for transport's implementation so it can be used in FastCS."""
 
     subclasses: ClassVar[list[type["Transport"]]] = []
 
@@ -24,13 +22,13 @@ class Transport:
         return Union[tuple(cls.subclasses)]  # noqa: UP007
 
     @abstractmethod
-    def connect(
-        self, controller_api: ControllerAPI, loop: asyncio.AbstractEventLoop
-    ) -> None:
-        """Connect the ``Transport`` to the control system
+    def connect(self, controller_api: ControllerAPI) -> None:
+        """Connect the `Transport` to the control system
 
-        The `ControllerAPI` should be exposed over the transport. The provided event
-        loop should be used where required instead of creating a new one.
+        The `ControllerAPI` should be exposed over the transport. Transports that
+        require the event loop should retrieve it in `serve` with
+        `asyncio.get_running_loop`, as this method is called from within an async
+        context.
 
         """
         pass
@@ -48,8 +46,9 @@ class Transport:
     async def serve(self) -> None:
         """Serve the `ControllerAPI`
 
-        This method will be spawned as an async background task in before launching the
-        interactive shell, so it can (but doesn't have to) block and run forever.
+        This method will be called in an async context as a background task before
+        launching the interactive shell, so it can (but doesn't have to) block and run
+        forever. To retrieve the fastcs event loop use `asyncio.get_running_loop`.
 
         """
         pass

--- a/tests/benchmarking/controller.py
+++ b/tests/benchmarking/controller.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from fastcs import FastCS
 from fastcs.attributes import AttrR, AttrW
 from fastcs.controllers import Controller
@@ -25,7 +23,7 @@ def run():
         ),
         TangoTransport(tango=TangoDSROptions(dev_name="MY/BENCHMARK/DEVICE")),
     ]
-    instance = FastCS(MyTestController(), transport_options, asyncio.get_event_loop())
+    instance = FastCS(MyTestController(), transport_options)
     instance.run()
 
 

--- a/tests/test_control_system.py
+++ b/tests/test_control_system.py
@@ -13,9 +13,8 @@ from fastcs.util import ONCE
 
 @pytest.mark.asyncio
 async def test_scan_tasks(controller):
-    loop = asyncio.get_event_loop()
     transport_options = []
-    fastcs = FastCS(controller, transport_options, loop)
+    fastcs = FastCS(controller, transport_options)
 
     asyncio.create_task(fastcs.serve(interactive=False))
     await asyncio.sleep(0.1)
@@ -43,9 +42,8 @@ async def test_controller_api_methods():
             pass
 
     controller = MyTestController()
-    loop = asyncio.get_event_loop()
     transport_options = []
-    fastcs = FastCS(controller, transport_options, loop)
+    fastcs = FastCS(controller, transport_options)
 
     asyncio.create_task(fastcs.serve(interactive=False))
     await asyncio.sleep(0.1)
@@ -79,9 +77,7 @@ async def test_update_periods():
         )
 
     controller = MyController(ios=[AttributeIOTimesCalled()])
-    loop = asyncio.get_event_loop()
-
-    fastcs = FastCS(controller, [], loop)
+    fastcs = FastCS(controller, [])
 
     assert controller.update_quickly.get() == 0
     assert controller.update_once.get() == 0
@@ -108,9 +104,7 @@ async def test_controller_connect_disconnect():
             self.connected = False
 
     controller = MyTestController()
-
-    loop = asyncio.get_event_loop()
-    fastcs = FastCS(controller, [], loop)
+    fastcs = FastCS(controller, [])
 
     task = asyncio.create_task(fastcs.serve(interactive=False))
 

--- a/tests/transports/epics/ca/test_initial_value.py
+++ b/tests/transports/epics/ca/test_initial_value.py
@@ -51,12 +51,10 @@ class InitialValuesController(Controller):
 async def test_initial_values_set_in_ca(mocker):
     pv_prefix = "SOFTIOC_INITIAL_DEVICE"
 
-    loop = asyncio.get_event_loop()
     controller = InitialValuesController()
     fastcs = FastCS(
         controller,
         [EpicsCATransport(epicsca=EpicsIOCOptions(pv_prefix=pv_prefix))],
-        loop,
     )
 
     record_spy = mocker.spy(ca_ioc, "_make_in_record")

--- a/tests/transports/epics/pva/test_p4p.py
+++ b/tests/transports/epics/pva/test_p4p.py
@@ -216,7 +216,8 @@ def make_fastcs(pv_prefix: str, controller: Controller) -> FastCS:
     )
 
 
-def test_read_signal_set():
+@pytest.mark.asyncio
+async def test_read_signal_set():
     class SomeController(Controller):
         a: AttrRW = AttrRW(Int(max=400_000, max_alarm=40_000))
         b: AttrR = AttrR(Float(min=-1, min_alarm=-0.5, prec=2))
@@ -240,12 +241,10 @@ def test_read_signal_set():
     a_values, b_values = [], []
     a_monitor = ctxt.monitor(f"{pv_prefix}:A_RBV", a_values.append)
     b_monitor = ctxt.monitor(f"{pv_prefix}:B", b_values.append)
-    serve = asyncio.ensure_future(fastcs.serve(interactive=False))
-    wait_and_set_attr_r = asyncio.ensure_future(_wait_and_set_attr_r())
+    serve = asyncio.create_task(fastcs.serve(interactive=False))
+    wait_and_set_attr_r = asyncio.create_task(_wait_and_set_attr_r())
     try:
-        asyncio.get_event_loop().run_until_complete(
-            asyncio.wait_for(asyncio.gather(serve, wait_and_set_attr_r), timeout=0.2)
-        )
+        await asyncio.wait_for(asyncio.gather(serve, wait_and_set_attr_r), timeout=0.2)
     except TimeoutError:
         ...
     finally:
@@ -257,7 +256,8 @@ def test_read_signal_set():
         assert b_values == [0.0, -0.99, -0.91]  # Last is -0.91 because of prec
 
 
-def test_pvi_grouping():
+@pytest.mark.asyncio
+async def test_pvi_grouping():
     class ChildChildController(Controller):
         attr_e: AttrRW = AttrRW(Int())
         attr_f: AttrR = AttrR(String())
@@ -321,12 +321,10 @@ def test_pvi_grouping():
     child_child_child_controller_monitor = ctxt.monitor(
         f"{pv_prefix}Child:0:ChildChild:PVI", child_child_child_controller_pvi.append
     )
-    serve = asyncio.ensure_future(fastcs.serve(interactive=False))
+    serve = asyncio.create_task(fastcs.serve(interactive=False))
 
     try:
-        asyncio.get_event_loop().run_until_complete(
-            asyncio.wait_for(serve, timeout=0.2)
-        )
+        await asyncio.wait_for(serve, timeout=0.2)
     except TimeoutError:
         ...
     finally:
@@ -525,7 +523,8 @@ async def test_more_exotic_datatypes():
         )
 
 
-def test_command_method_put_twice(caplog):
+@pytest.mark.asyncio
+async def test_command_method_put_twice(caplog):
     class SomeController(Controller):
         command_runs_for_a_while_times = []
         command_spawns_a_task_times = []
@@ -572,11 +571,9 @@ def test_command_method_put_twice(caplog):
         )
         assert expected_error_string in caplog.text
 
-    serve = asyncio.ensure_future(fastcs.serve(interactive=False))
+    serve = asyncio.create_task(fastcs.serve(interactive=False))
     try:
-        asyncio.get_event_loop().run_until_complete(
-            asyncio.wait_for(asyncio.gather(serve, put_pvs()), timeout=1)
-        )
+        await asyncio.wait_for(asyncio.gather(serve, put_pvs()), timeout=1)
     except TimeoutError:
         ...
     serve.cancel()
@@ -613,7 +610,8 @@ def test_command_method_put_twice(caplog):
     )
 
 
-def test_block_flag_waits_for_callback_completion():
+@pytest.mark.asyncio
+async def test_block_flag_waits_for_callback_completion():
     class SomeController(Controller):
         @command()
         async def command_runs_for_a_while(self):
@@ -635,14 +633,9 @@ def test_block_flag_waits_for_callback_completion():
             )
             command_runs_for_a_while_times.append((start_time, datetime.now()))
 
-    serve = asyncio.ensure_future(fastcs.serve(interactive=False))
+    serve = asyncio.create_task(fastcs.serve(interactive=False))
     try:
-        asyncio.get_event_loop().run_until_complete(
-            asyncio.wait_for(
-                asyncio.gather(serve, put_pvs()),
-                timeout=0.5,
-            )
-        )
+        await asyncio.wait_for(asyncio.gather(serve, put_pvs()), timeout=0.5)
     except TimeoutError:
         ...
     serve.cancel()

--- a/tests/transports/graphQL/test_graphql.py
+++ b/tests/transports/graphQL/test_graphql.py
@@ -1,4 +1,3 @@
-import asyncio
 import copy
 import json
 from typing import Any
@@ -66,7 +65,7 @@ def nest_response(path: list[str], value: Any) -> dict:
 
 def create_test_client(gql_controller_api: AssertableControllerAPI) -> TestClient:
     graphql_transport = GraphQLTransport()
-    graphql_transport.connect(gql_controller_api, asyncio.AbstractEventLoop())
+    graphql_transport.connect(gql_controller_api)
     return TestClient(graphql_transport._server._app)
 
 

--- a/tests/transports/rest/test_rest.py
+++ b/tests/transports/rest/test_rest.py
@@ -1,4 +1,3 @@
-import asyncio
 import enum
 
 import numpy as np
@@ -32,7 +31,7 @@ def rest_controller_api(class_mocker: MockerFixture):
 
 def create_test_client(rest_controller_api: ControllerAPI) -> TestClient:
     rest_transport = RestTransport()
-    rest_transport.connect(rest_controller_api, asyncio.AbstractEventLoop())
+    rest_transport.connect(rest_controller_api)
     return TestClient(rest_transport._server._app)
 
 

--- a/tests/transports/tango/test_dsr.py
+++ b/tests/transports/tango/test_dsr.py
@@ -1,5 +1,6 @@
 import asyncio
 import enum
+import gc
 
 import numpy as np
 import pytest
@@ -13,7 +14,7 @@ from tests.assertable_controller import (
 
 from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.datatypes import Bool, Enum, Float, Int, String, Waveform
-from fastcs.transports.tango.transport import TangoTransport
+from fastcs.transports.tango.dsr import TangoDSR
 
 
 async def patch_run_threadsafe_blocking(coro, loop):
@@ -47,17 +48,24 @@ def tango_controller_api(class_mocker: MockerFixture) -> AssertableControllerAPI
 
 
 def create_test_context(tango_controller_api: AssertableControllerAPI):
-    tango_transport = TangoTransport()
-    tango_transport.connect(
-        tango_controller_api,
-        asyncio.get_event_loop(),
-    )
-    device = tango_transport._dsr._device
+    loop = asyncio.new_event_loop()
+    dsr = TangoDSR(tango_controller_api, loop)
+
     # https://tango-controls.readthedocs.io/projects/pytango/en/v9.5.1/testing/test_context.html
-    with DeviceTestContext(device, debug=0) as proxy:
+    with DeviceTestContext(dsr._device, debug=0) as proxy:
         yield proxy
 
+    loop.close()
 
+    # Force GC now so that any ResourceWarnings from DeviceTestContext (unclosed
+    # sockets/event loop leaked by Tango at the C level) are raised here, within
+    # the scope of the filterwarnings markers on TestTangoDevice, rather than
+    # after teardown where they cannot be suppressed per-test.
+    gc.collect()
+
+
+@pytest.mark.filterwarnings("ignore:unclosed <socket\\.socket:ResourceWarning")
+@pytest.mark.filterwarnings("ignore:unclosed event loop:ResourceWarning")
 class TestTangoDevice:
     @pytest.fixture(scope="class")
     def tango_context(


### PR DESCRIPTION
- [x] Merge #338 first

---

In the process of writing documentation it became clear that

- We are using get_event_loop, which is deprecated and planned for removal in 3.16
- The event loop handling is over complicated

Summary:
- Remove the `loop` parameter to `FastCS` and instead require clients to call `serve` from an async context with the loop they want it to run in
- Don't pass a `loop` to transports and instead retrieve it via `get_running_loop` only where required (EpicaCA and Tango)
- Use `asyncio.create_task` from an async context consistently in tests, rather than `run_until_complete` or `ensure_future`
- Improve tango test handling of DeviceTestContext to fix resource warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Components no longer require supplying an explicit event loop; runtime loop is obtained internally, and task scheduling uses modern asyncio APIs.
* **Documentation**
  * Added a comprehensive guide covering startup, runtime, interactive shell, and shutdown flows.
* **Tests**
  * Updated tests to modern async patterns and to match the simplified startup/connect flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->