### PR TITLE
refactor: bind attributes and methods in insertion order

### DIFF
--- a/src/fastcs/controllers/base_controller.py
+++ b/src/fastcs/controllers/base_controller.py
@@ -98,10 +98,27 @@ class BaseController(Tracer):
             elif isinstance(hint, type) and issubclass(hint, Method):
                 self.__hinted_methods[name] = hint
 
-    def _bind_attrs(self) -> None:
-        """Search for Attributes and Methods to bind them to this instance.
+    @classmethod
+    def _walk_mro(cls):
+        """Return ordered attribute names from the class MRO.
 
-        This method will search the attributes of this controller class to bind them to
+        Traverses MRO from base to subclass, collecting attribute names in definition
+        order while skipping duplicates (subclass overrides take precedence) and private
+        attributes.
+        """
+        class_dir = []
+        seen = set()
+        for base in reversed(cls.__mro__):
+            for key in base.__dict__:
+                if not key.startswith("_") and key not in seen:
+                    seen.add(key)
+                    class_dir.append(key)
+        return class_dir
+
+    def _bind_attrs(self) -> None:
+        """Bind Attributes and Methods to this instance.
+
+        This method will bind the attributes of this controller class to
         this specific instance. For Attributes, this is just a case of copying and
         re-assigning to ``self`` to make it unique across multiple instances of this
         controller class. For Methods, this requires creating a bound method from a
@@ -109,8 +126,7 @@ class BaseController(Tracer):
         context with the controller instance passed as the ``self`` argument.
 
         """
-        # Using a dictionary instead of a set to maintain order.
-        class_dir = {key: None for key in dir(type(self)) if not key.startswith("_")}
+        class_dir = dict.fromkeys(self._walk_mro())
         class_type_hints = {
             key: value
             for key, value in get_type_hints(type(self)).items()

--- a/tests/transports/epics/ca/test_gui.py
+++ b/tests/transports/epics/ca/test_gui.py
@@ -125,22 +125,9 @@ def test_get_components(controller_api):
                 )
             ],
         ),
-        SignalR(name="ReadBool", read_pv="DEVICE:ReadBool", read_widget=LED()),
         SignalR(
             name="ReadInt",
             read_pv="DEVICE:ReadInt",
-            read_widget=TextRead(),
-        ),
-        SignalRW(
-            name="ReadString",
-            read_pv="DEVICE:ReadString_RBV",
-            write_pv="DEVICE:ReadString",
-        ),
-        SignalRW(
-            name="ReadWriteFloat",
-            write_pv="DEVICE:ReadWriteFloat",
-            write_widget=TextWrite(),
-            read_pv="DEVICE:ReadWriteFloat_RBV",
             read_widget=TextRead(),
         ),
         SignalRW(
@@ -150,10 +137,27 @@ def test_get_components(controller_api):
             read_pv="DEVICE:ReadWriteInt_RBV",
             read_widget=TextRead(),
         ),
+        SignalRW(
+            name="ReadWriteFloat",
+            write_pv="DEVICE:ReadWriteFloat",
+            write_widget=TextWrite(),
+            read_pv="DEVICE:ReadWriteFloat_RBV",
+            read_widget=TextRead(),
+        ),
+        SignalR(
+            name="ReadBool",
+            read_pv="DEVICE:ReadBool",
+            read_widget=LED(),
+        ),
         SignalW(
             name="WriteBool",
             write_pv="DEVICE:WriteBool",
             write_widget=ToggleButton(),
+        ),
+        SignalRW(
+            name="ReadString",
+            read_pv="DEVICE:ReadString_RBV",
+            write_pv="DEVICE:ReadString",
         ),
         SignalX(
             name="Go",

--- a/tests/transports/tango/test_dsr.py
+++ b/tests/transports/tango/test_dsr.py
@@ -69,15 +69,15 @@ class TestTangoDevice:
 
     def test_list_attributes(self, tango_context: DeviceProxy):
         assert list(tango_context.get_attribute_list()) == [
+            "ReadInt",
+            "ReadWriteInt",
+            "ReadWriteFloat",
+            "ReadBool",
+            "WriteBool",
+            "ReadString",
             "Enum",
             "OneDWaveform",
-            "ReadBool",
-            "ReadInt",
-            "ReadString",
-            "ReadWriteFloat",
-            "ReadWriteInt",
             "TwoDWaveform",
-            "WriteBool",
             "SubController01_ReadInt",
             "SubController02_ReadInt",
             "State",


### PR DESCRIPTION
closes #344 

This PR replaces the use of `dir()` to search for attributes and methods with walking the class `MRO`; this provides us with insertion order, and inherited attributes (which `__dict__` would not provide). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how attributes are ordered during controller initialization by implementing explicit method resolution order walking, resulting in more predictable and deterministic attribute binding behavior.

* **Tests**
  * Updated test expectations for GUI components and attribute listings to align with the new attribute binding order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->