### PR TITLE
Fix the docstring for Tracer class

### DIFF
--- a/src/fastcs/tracer.py
+++ b/src/fastcs/tracer.py
@@ -23,6 +23,7 @@ class Tracer:
     be logged
 
     Example usage in interactive shell:
+
     .. code-block:: python
 
         controller.ramp_rate.enable_tracing()


### PR DESCRIPTION
The current [docs for the Tracer class](https://diamondlightsource.github.io/fastcs/main/_api/fastcs.tracer.html#fastcs.tracer.Tracer) do not render correctly. This fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of example documentation for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DiamondLightSource/fastcs/pull/377)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->