### PR TITLE
feat: allow aliases to be passed to ca transport

### DIFF
--- a/src/fastcs/demo/schema.json
+++ b/src/fastcs/demo/schema.json
@@ -2,7 +2,15 @@
   "$defs": {
     "EpicsCAOptions": {
       "additionalProperties": false,
-      "properties": {},
+      "properties": {
+        "aliases": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Aliases",
+          "type": "object"
+        }
+      },
       "title": "EpicsCAOptions",
       "type": "object"
     },

--- a/src/fastcs/transports/epics/ca/ioc.py
+++ b/src/fastcs/transports/epics/ca/ioc.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import Counter
 from typing import Any, Literal
 
 from softioc import builder, softioc
@@ -29,6 +30,14 @@ class EpicsCAIOC:
     """A softioc which handles one or more controllers."""
 
     def __init__(self, controller_apis: list[ControllerAPI], aliases: dict[str, str]):
+        if duplicate_aliases := [
+            alias for alias, count in Counter(aliases.values()).items() if count > 1
+        ]:
+            raise RuntimeError(
+                "Failed to create EPICS CA IOC, as duplicate aliases were provided:"
+                f" {duplicate_aliases}"
+            )
+
         self._controller_apis = controller_apis
         for controller_api in controller_apis:
             root_pv_prefix = pv_prefix_from_path(controller_api.path)
@@ -319,4 +328,10 @@ def _add_attr_pvi_info(
 
 def _add_alias(record: RecordWrapper, alias: str | None):
     if alias is not None:
-        record.add_alias(alias)
+        if len(alias) > EPICS_MAX_NAME_LENGTH:
+            logger.warning(
+                f"Not creating alias {alias}, as full name would exceed"
+                f" {EPICS_MAX_NAME_LENGTH} characters"
+            )
+        else:
+            record.add_alias(alias)

--- a/src/fastcs/transports/epics/ca/ioc.py
+++ b/src/fastcs/transports/epics/ca/ioc.py
@@ -34,7 +34,7 @@ class EpicsCAIOC:
             _add_sub_controller_pvi_info(controller_api)
 
             _create_and_link_attribute_pvs(controller_api, aliases)
-            _create_and_link_command_pvs(controller_api)
+            _create_and_link_command_pvs(controller_api, aliases)
 
     def run(
         self,
@@ -223,12 +223,15 @@ def _create_and_link_write_pv(
     attribute.add_sync_setpoint_callback(set_setpoint_without_process)
 
 
-def _create_and_link_command_pvs(root_controller_api: ControllerAPI) -> None:
+def _create_and_link_command_pvs(
+    root_controller_api: ControllerAPI, aliases: dict[str, str]
+) -> None:
     for controller_api in root_controller_api.walk_api():
         pv_prefix = pv_prefix_from_path(controller_api.path)
 
         for attr_name, method in controller_api.command_methods.items():
             pv_name = snake_to_pascal(attr_name)
+            alias = aliases.get(f"{pv_prefix}:{pv_name}", None)
 
             if len(f"{pv_prefix}:{pv_name}") > EPICS_MAX_NAME_LENGTH:
                 print(
@@ -241,12 +244,13 @@ def _create_and_link_command_pvs(root_controller_api: ControllerAPI) -> None:
                     pv_prefix,
                     pv_name,
                     attr_name,
+                    alias,
                     method,
                 )
 
 
 def _create_and_link_command_pv(
-    pv_prefix: str, pv_name: str, attr_name: str, method: Command
+    pv_prefix: str, pv_name: str, attr_name: str, alias: str | None, method: Command
 ) -> None:
     pv = f"{pv_prefix}:{pv_name}"
 
@@ -263,6 +267,9 @@ def _create_and_link_command_pv(
         ZNAM="Idle",
         ONAM="Active",
     )
+
+    if alias:
+        record.add_alias(alias)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "x")
 

--- a/src/fastcs/transports/epics/ca/ioc.py
+++ b/src/fastcs/transports/epics/ca/ioc.py
@@ -26,14 +26,14 @@ tracer = Tracer()
 class EpicsCAIOC:
     """A softioc which handles one or more controllers."""
 
-    def __init__(self, controller_apis: list[ControllerAPI]):
+    def __init__(self, controller_apis: list[ControllerAPI], aliases: dict[str, str]):
         self._controller_apis = controller_apis
         for controller_api in controller_apis:
             root_pv_prefix = pv_prefix_from_path(controller_api.path)
             _add_pvi_info(f"{root_pv_prefix}:PVI")
             _add_sub_controller_pvi_info(controller_api)
 
-            _create_and_link_attribute_pvs(controller_api)
+            _create_and_link_attribute_pvs(controller_api, aliases)
             _create_and_link_command_pvs(controller_api)
 
     def run(
@@ -107,7 +107,9 @@ def _add_sub_controller_pvi_info(parent: ControllerAPI):
         _add_sub_controller_pvi_info(child)
 
 
-def _create_and_link_attribute_pvs(root_controller_api: ControllerAPI) -> None:
+def _create_and_link_attribute_pvs(
+    root_controller_api: ControllerAPI, aliases: dict[str, str]
+) -> None:
     for controller_api in root_controller_api.walk_api():
         pv_prefix = pv_prefix_from_path(controller_api.path)
 
@@ -133,6 +135,7 @@ def _create_and_link_attribute_pvs(root_controller_api: ControllerAPI) -> None:
                 )
                 continue
 
+            alias = aliases.get(f"{pv_prefix}:{pv_name}", None)
             match attribute:
                 case AttrRW():
                     if full_pv_name_length > (EPICS_MAX_NAME_LENGTH - 4):
@@ -144,19 +147,31 @@ def _create_and_link_attribute_pvs(root_controller_api: ControllerAPI) -> None:
                         attribute.enabled = False
                     else:
                         _create_and_link_read_pv(
-                            pv_prefix, f"{pv_name}_RBV", attr_name, attribute
+                            pv_prefix, f"{pv_name}_RBV", attr_name, alias, attribute
                         )
                         _create_and_link_write_pv(
-                            pv_prefix, pv_name, attr_name, attribute
+                            pv_prefix, pv_name, attr_name, alias, attribute
                         )
                 case AttrR():
-                    _create_and_link_read_pv(pv_prefix, pv_name, attr_name, attribute)
+                    _create_and_link_read_pv(
+                        pv_prefix,
+                        pv_name,
+                        attr_name,
+                        alias,
+                        attribute,
+                    )
                 case AttrW():
-                    _create_and_link_write_pv(pv_prefix, pv_name, attr_name, attribute)
+                    _create_and_link_write_pv(
+                        pv_prefix, pv_name, attr_name, alias, attribute
+                    )
 
 
 def _create_and_link_read_pv(
-    pv_prefix: str, pv_name: str, attr_name: str, attribute: AttrR[DType_T]
+    pv_prefix: str,
+    pv_name: str,
+    attr_name: str,
+    alias: str | None,
+    attribute: AttrR[DType_T],
 ) -> None:
     pv = f"{pv_prefix}:{pv_name}"
 
@@ -168,13 +183,22 @@ def _create_and_link_read_pv(
         record.set(cast_to_epics_type(attribute.datatype, value))
 
     record = _make_in_record(pv, attribute)
+
+    if alias:
+        suffix = "_RBV" if pv_name.endswith("_RBV") else ""
+        record.add_alias(f"{alias}{suffix}")
+
     _add_attr_pvi_info(record, pv_prefix, attr_name, "r")
 
     attribute.add_on_update_callback(async_record_set)
 
 
 def _create_and_link_write_pv(
-    pv_prefix: str, pv_name: str, attr_name: str, attribute: AttrW[DType_T]
+    pv_prefix: str,
+    pv_name: str,
+    attr_name: str,
+    alias: str | None,
+    attribute: AttrW[DType_T],
 ) -> None:
     pv = f"{pv_prefix}:{pv_name}"
 
@@ -191,6 +215,8 @@ def _create_and_link_write_pv(
         record.set(cast_to_epics_type(attribute.datatype, value), process=False)
 
     record = _make_out_record(pv, attribute, on_update=on_update)
+    if alias:
+        record.add_alias(alias)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "w")
 

--- a/src/fastcs/transports/epics/ca/ioc.py
+++ b/src/fastcs/transports/epics/ca/ioc.py
@@ -22,6 +22,8 @@ from fastcs.util import snake_to_pascal
 
 tracer = Tracer()
 
+RBV_SUFFIX = "_RBV"
+
 
 class EpicsCAIOC:
     """A softioc which handles one or more controllers."""
@@ -146,11 +148,22 @@ def _create_and_link_attribute_pvs(
                         )
                         attribute.enabled = False
                     else:
+                        alias_rbv = aliases.get(
+                            f"{pv_prefix}:{pv_name}{RBV_SUFFIX}", None
+                        )
                         _create_and_link_read_pv(
-                            pv_prefix, f"{pv_name}_RBV", attr_name, alias, attribute
+                            pv_prefix,
+                            f"{pv_name}{RBV_SUFFIX}",
+                            attr_name,
+                            alias_rbv,
+                            attribute,
                         )
                         _create_and_link_write_pv(
-                            pv_prefix, pv_name, attr_name, alias, attribute
+                            pv_prefix,
+                            pv_name,
+                            attr_name,
+                            alias,
+                            attribute,
                         )
                 case AttrR():
                     _create_and_link_read_pv(
@@ -162,7 +175,11 @@ def _create_and_link_attribute_pvs(
                     )
                 case AttrW():
                     _create_and_link_write_pv(
-                        pv_prefix, pv_name, attr_name, alias, attribute
+                        pv_prefix,
+                        pv_name,
+                        attr_name,
+                        alias,
+                        attribute,
                     )
 
 
@@ -184,9 +201,7 @@ def _create_and_link_read_pv(
 
     record = _make_in_record(pv, attribute)
 
-    if alias:
-        suffix = "_RBV" if pv_name.endswith("_RBV") else ""
-        record.add_alias(f"{alias}{suffix}")
+    _add_alias(record, alias)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "r")
 
@@ -215,8 +230,8 @@ def _create_and_link_write_pv(
         record.set(cast_to_epics_type(attribute.datatype, value), process=False)
 
     record = _make_out_record(pv, attribute, on_update=on_update)
-    if alias:
-        record.add_alias(alias)
+
+    _add_alias(record, alias)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "w")
 
@@ -268,8 +283,7 @@ def _create_and_link_command_pv(
         ONAM="Active",
     )
 
-    if alias:
-        record.add_alias(alias)
+    _add_alias(record, alias)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "x")
 
@@ -301,3 +315,8 @@ def _add_attr_pvi_info(
             }
         },
     )
+
+
+def _add_alias(record: RecordWrapper, alias: str | None):
+    if alias is not None:
+        record.add_alias(alias)

--- a/src/fastcs/transports/epics/ca/transport.py
+++ b/src/fastcs/transports/epics/ca/transport.py
@@ -43,7 +43,7 @@ class EpicsCATransport(Transport):
         self._controller_apis = controller_apis
         self._loop = loop
         self._pv_prefixes = [pv_prefix_from_path(api.path) for api in controller_apis]
-        self._ioc = EpicsCAIOC(controller_apis)
+        self._ioc = EpicsCAIOC(controller_apis, self.epicsca.aliases)
 
         if self.docs is not None:
             emit_docs_files(controller_apis, self.docs)

--- a/src/fastcs/transports/epics/options.py
+++ b/src/fastcs/transports/epics/options.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import ClassVar
@@ -40,6 +40,8 @@ class EpicsCAOptions:
     """
 
     __pydantic_config__: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    aliases: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/fastcs/transports/epics/options.py
+++ b/src/fastcs/transports/epics/options.py
@@ -42,6 +42,10 @@ class EpicsCAOptions:
     __pydantic_config__: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     aliases: dict[str, str] = field(default_factory=dict)
+    """Mapping of fastcs PV names to their aliases.
+
+    Setpoint and readback PVs must be aliased separately.
+    """
 
 
 @dataclass

--- a/tests/data/schema.json
+++ b/tests/data/schema.json
@@ -2,7 +2,15 @@
   "$defs": {
     "EpicsCAOptions": {
       "additionalProperties": false,
-      "properties": {},
+      "properties": {
+        "aliases": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Aliases",
+          "type": "object"
+        }
+      },
       "title": "EpicsCAOptions",
       "type": "object"
     },

--- a/tests/example_softioc.py
+++ b/tests/example_softioc.py
@@ -5,7 +5,11 @@ from fastcs.control_system import FastCS
 from fastcs.controllers import Controller, ControllerVector
 from fastcs.datatypes import Int
 from fastcs.methods import command
-from fastcs.transports.epics.ca.transport import EpicsCATransport, EpicsGUIOptions
+from fastcs.transports.epics.ca.transport import (
+    EpicsCAOptions,
+    EpicsCATransport,
+    EpicsGUIOptions,
+)
 
 
 class ParentController(Controller):
@@ -29,7 +33,12 @@ def run(id="SOFTIOC_TEST_DEVICE"):
     gui_options = EpicsGUIOptions(output_dir=Path("."), title="Demo Vector")
     fastcs = FastCS(
         controller,
-        [EpicsCATransport(gui=gui_options)],
+        [
+            EpicsCATransport(
+                epicsca=EpicsCAOptions(aliases={f"{id}:B": f"{id}:AliasB"}),
+                gui=gui_options,
+            )
+        ],
     )
     fastcs.run(interactive=False)
 

--- a/tests/example_softioc.py
+++ b/tests/example_softioc.py
@@ -35,7 +35,12 @@ def run(id="SOFTIOC_TEST_DEVICE"):
         controller,
         [
             EpicsCATransport(
-                epicsca=EpicsCAOptions(aliases={f"{id}:B": f"{id}:AliasB"}),
+                epicsca=EpicsCAOptions(
+                    aliases={
+                        f"{id}:B": f"{id}:AliasB",
+                        f"{id}:B_RBV": f"{id}:AliasB_RBV",
+                    }
+                ),
                 gui=gui_options,
             )
         ],

--- a/tests/transports/epics/ca/test_softioc.py
+++ b/tests/transports/epics/ca/test_softioc.py
@@ -628,7 +628,7 @@ def test_non_1d_waveforms_discarded(mocker: MockerFixture):
     EpicsCAIOC([api], {})
 
     create_mock.assert_called_once_with(
-        DEVICE, "Waveform1d", "waveform_1d", api.attributes["waveform_1d"]
+        DEVICE, "Waveform1d", "waveform_1d", None, api.attributes["waveform_1d"]
     )
 
 

--- a/tests/transports/epics/ca/test_softioc.py
+++ b/tests/transports/epics/ca/test_softioc.py
@@ -1,4 +1,5 @@
 import enum
+import re
 from typing import Any
 
 import numpy as np
@@ -20,6 +21,7 @@ from fastcs.methods import Command
 from fastcs.transports.epics.ca import EpicsCATransport
 from fastcs.transports.epics.ca.ioc import (
     EpicsCAIOC,
+    _add_alias,
     _add_attr_pvi_info,
     _add_pvi_info,
     _add_sub_controller_pvi_info,
@@ -111,6 +113,39 @@ async def test_create_and_link_command_pv_adds_alias(mocker: MockerFixture):
         ONAM="Active",
     )
     record.add_alias.assert_called_once_with("alias")
+
+
+@pytest.mark.asyncio
+async def test_add_alias_skips_alias_if_too_long(mocker: MockerFixture):
+    alias_name = "alias"
+
+    # mock EPICS_MAX_NAME_LENGTH such that length of alias is at this maximum
+    mocker.patch(
+        "fastcs.transports.epics.ca.ioc.EPICS_MAX_NAME_LENGTH",
+        len(alias_name),
+    )
+
+    # lengthen alias name beyond maximum
+    too_long_alias_name = f"long_{alias_name}"
+
+    record = mocker.MagicMock()
+    _add_alias(record, alias_name)
+    record.add_alias.assert_called_once_with(alias_name)
+
+    _add_alias(record, too_long_alias_name)
+
+    with pytest.raises(AssertionError):
+        # assert alias that is too long is not added
+        record.add_alias.assert_called_once_with(too_long_alias_name)
+
+
+@pytest.mark.asyncio
+async def test_ioc_raises_if_duplicate_aliases_provided(mocker: MockerFixture):
+    aliases = {"A": "Alias", "B": "Alias"}
+    with pytest.raises(
+        RuntimeError, match=re.escape("duplicate aliases were provided: ['Alias']")
+    ):
+        EpicsCAIOC(mocker.MagicMock(), aliases)
 
 
 @pytest.mark.parametrize(

--- a/tests/transports/epics/ca/test_softioc.py
+++ b/tests/transports/epics/ca/test_softioc.py
@@ -81,7 +81,7 @@ async def test_create_and_link_write_pv_adds_alias(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_create_and_link_read_pv_adds_alias_with_rbv(mocker: MockerFixture):
+async def test_create_and_link_read_pv_adds_alias(mocker: MockerFixture):
     make_record = mocker.patch("fastcs.transports.epics.ca.ioc._make_in_record")
     record = make_record.return_value
     record.add_alias = mocker.MagicMock()
@@ -90,7 +90,7 @@ async def test_create_and_link_read_pv_adds_alias_with_rbv(mocker: MockerFixture
     _create_and_link_read_pv("PREFIX", "PV_RBV", "attr", "alias", attribute)
 
     make_record.assert_called_once_with("PREFIX:PV_RBV", attribute)
-    record.add_alias.assert_called_once_with("alias_RBV")
+    record.add_alias.assert_called_once_with("alias")
 
 
 @pytest.mark.asyncio

--- a/tests/transports/epics/ca/test_softioc.py
+++ b/tests/transports/epics/ca/test_softioc.py
@@ -23,6 +23,7 @@ from fastcs.transports.epics.ca.ioc import (
     _add_attr_pvi_info,
     _add_pvi_info,
     _add_sub_controller_pvi_info,
+    _create_and_link_command_pv,
     _create_and_link_read_pv,
     _create_and_link_write_pv,
 )
@@ -90,6 +91,26 @@ async def test_create_and_link_read_pv_adds_alias_with_rbv(mocker: MockerFixture
 
     make_record.assert_called_once_with("PREFIX:PV_RBV", attribute)
     record.add_alias.assert_called_once_with("alias_RBV")
+
+
+@pytest.mark.asyncio
+async def test_create_and_link_command_pv_adds_alias(mocker: MockerFixture):
+    make_action = mocker.patch("fastcs.transports.epics.ca.ioc.builder.Action")
+    record = make_action.return_value
+    record.add_alias = mocker.MagicMock()
+    command = mocker.MagicMock()
+
+    _create_and_link_command_pv("PREFIX", "Command", "command", "alias", command)
+
+    make_action.assert_called_once_with(
+        "PREFIX:Command",
+        on_update=mocker.ANY,
+        blocking=True,
+        initial_value=0,
+        ZNAM="Idle",
+        ONAM="Active",
+    )
+    record.add_alias.assert_called_once_with("alias")
 
 
 @pytest.mark.parametrize(

--- a/tests/transports/epics/ca/test_softioc.py
+++ b/tests/transports/epics/ca/test_softioc.py
@@ -53,7 +53,7 @@ async def test_create_and_link_read_pv(mocker: MockerFixture):
     attribute = AttrR(Int())
     attribute.add_on_update_callback = mocker.MagicMock()
 
-    _create_and_link_read_pv("PREFIX", "PV", "attr", attribute)
+    _create_and_link_read_pv("PREFIX", "PV", "attr", None, attribute)
 
     make_record.assert_called_once_with("PREFIX:PV", attribute)
     add_attr_pvi_info.assert_called_once_with(record, "PREFIX", "attr", "r")
@@ -64,6 +64,32 @@ async def test_create_and_link_read_pv(mocker: MockerFixture):
     await record_set_callback(1)
 
     record.set.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_create_and_link_write_pv_adds_alias(mocker: MockerFixture):
+    make_record = mocker.patch("fastcs.transports.epics.ca.ioc._make_out_record")
+    record = make_record.return_value
+    record.add_alias = mocker.MagicMock()
+    attribute = mocker.MagicMock()
+
+    _create_and_link_write_pv("PREFIX", "PV", "attr", "alias", attribute)
+
+    make_record.assert_called_once_with("PREFIX:PV", attribute, on_update=mocker.ANY)
+    record.add_alias.assert_called_once_with("alias")
+
+
+@pytest.mark.asyncio
+async def test_create_and_link_read_pv_adds_alias_with_rbv(mocker: MockerFixture):
+    make_record = mocker.patch("fastcs.transports.epics.ca.ioc._make_in_record")
+    record = make_record.return_value
+    record.add_alias = mocker.MagicMock()
+    attribute = mocker.MagicMock()
+
+    _create_and_link_read_pv("PREFIX", "PV_RBV", "attr", "alias", attribute)
+
+    make_record.assert_called_once_with("PREFIX:PV_RBV", attribute)
+    record.add_alias.assert_called_once_with("alias_RBV")
 
 
 @pytest.mark.parametrize(
@@ -150,7 +176,7 @@ async def test_create_and_link_write_pv(mocker: MockerFixture):
     attribute.put = mocker.AsyncMock()
     attribute.add_sync_setpoint_callback = mocker.MagicMock()
 
-    _create_and_link_write_pv("PREFIX", "PV", "attr", attribute)
+    _create_and_link_write_pv("PREFIX", "PV", "attr", None, attribute)
 
     make_record.assert_called_once_with("PREFIX:PV", attribute, on_update=mocker.ANY)
     add_attr_pvi_info.assert_called_once_with(record, "PREFIX", "attr", "w")
@@ -284,7 +310,7 @@ def test_ioc(mocker: MockerFixture, epics_controller_api: ControllerAPI):
         "fastcs.transports.epics.ca.ioc._add_sub_controller_pvi_info"
     )
 
-    EpicsCAIOC([epics_controller_api])
+    EpicsCAIOC([epics_controller_api], {})
 
     # Check records are created
     util_builder.boolIn.assert_called_once_with(
@@ -510,7 +536,7 @@ def test_long_pv_names_discarded(mocker: MockerFixture):
     long_rw_name = "attr_rw_with_a_reallyreally_long_name_that_is_too_long_for_RBV"
     assert long_name_controller_api.attributes["attr_rw_short_name"].enabled
     assert long_name_controller_api.attributes[long_attr_name].enabled
-    EpicsCAIOC([long_name_controller_api])
+    EpicsCAIOC([long_name_controller_api], {})
     assert long_name_controller_api.attributes["attr_rw_short_name"].enabled
     assert not long_name_controller_api.attributes[long_attr_name].enabled
 
@@ -599,7 +625,7 @@ def test_non_1d_waveforms_discarded(mocker: MockerFixture):
     create_mock = mocker.patch(
         "fastcs.transports.epics.ca.ioc._create_and_link_read_pv"
     )
-    EpicsCAIOC([api])
+    EpicsCAIOC([api], {})
 
     create_mock.assert_called_once_with(
         DEVICE, "Waveform1d", "waveform_1d", api.attributes["waveform_1d"]

--- a/tests/transports/epics/ca/test_softioc_system.py
+++ b/tests/transports/epics/ca/test_softioc_system.py
@@ -51,4 +51,3 @@ def test_ioc(softioc_subprocess: tuple[str, Queue]):
     assert ctxt.get(f"{pv_prefix}:AliasB") == 10
     ctxt.put(f"{pv_prefix}:AliasB", 20)
     assert ctxt.get(f"{pv_prefix}:B") == 20
-    assert ctxt.get(f"{pv_prefix}:B_RBV") == ctxt.get(f"{pv_prefix}:AliasB_RBV") == 20

--- a/tests/transports/epics/ca/test_softioc_system.py
+++ b/tests/transports/epics/ca/test_softioc_system.py
@@ -49,3 +49,6 @@ def test_ioc(softioc_subprocess: tuple[str, Queue]):
     assert ctxt.get(f"{pv_prefix}:B") == ctxt.get(f"{pv_prefix}:AliasB") == 0
     ctxt.put(f"{pv_prefix}:B", 10)
     assert ctxt.get(f"{pv_prefix}:AliasB") == 10
+    ctxt.put(f"{pv_prefix}:AliasB", 20)
+    assert ctxt.get(f"{pv_prefix}:B") == 20
+    assert ctxt.get(f"{pv_prefix}:B_RBV") == ctxt.get(f"{pv_prefix}:AliasB_RBV") == 20

--- a/tests/transports/epics/ca/test_softioc_system.py
+++ b/tests/transports/epics/ca/test_softioc_system.py
@@ -44,3 +44,8 @@ def test_ioc(softioc_subprocess: tuple[str, Queue]):
         "c": {"w": f"{pv_prefix}:ChildVector:0:C"},
         "d": {"x": f"{pv_prefix}:ChildVector:0:D"},
     }
+
+    # Assert alias. Aliases do not show up in PVI structure
+    assert ctxt.get(f"{pv_prefix}:B") == ctxt.get(f"{pv_prefix}:AliasB") == 0
+    ctxt.put(f"{pv_prefix}:B", 10)
+    assert ctxt.get(f"{pv_prefix}:AliasB") == 10


### PR DESCRIPTION
Closes #384

This PR allows passing aliases to the `ca` transport. An Example would be:

```yaml
transport:
  - epicsca:
      aliases:
         - PV_TO_ALIAS: "ALIAS"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EPICS CA alias support via a new `aliases` transport option, registering alternate PV names for attributes, command PVs, and readback (`*_RBV`) variants.
  * Aliases are validated to prevent duplicate alias values; overly long alias names are skipped with a warning.
* **Tests**
  * Added coverage for alias registration for write, readback (`_RBV`), and command PVs, plus updated IOC initialization and expectations.
* **Documentation**
  * Updated the published EPICS CA options/schema to include the new `aliases` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->