### PR TITLE
add wait flag to context put operations in test

### DIFF
--- a/tests/transports/epics/ca/test_softioc_system.py
+++ b/tests/transports/epics/ca/test_softioc_system.py
@@ -47,7 +47,8 @@ def test_ioc(softioc_subprocess: tuple[str, Queue]):
 
     # Assert alias. Aliases do not show up in PVI structure
     assert ctxt.get(f"{pv_prefix}:B") == ctxt.get(f"{pv_prefix}:AliasB") == 0
-    ctxt.put(f"{pv_prefix}:B", 10)
+    ctxt.put(f"{pv_prefix}:B", 10, wait=True)
     assert ctxt.get(f"{pv_prefix}:AliasB") == 10
-    ctxt.put(f"{pv_prefix}:AliasB", 20)
+    ctxt.put(f"{pv_prefix}:AliasB", 20, wait=True)
     assert ctxt.get(f"{pv_prefix}:B") == 20
+    assert ctxt.get(f"{pv_prefix}:B_RBV") == ctxt.get(f"{pv_prefix}:AliasB_RBV") == 20


### PR DESCRIPTION
PR #385 passed CI, but this seems to have been a flaky pass, and is now failing main; this PR adds `wait=True` to `test_softioc_system`, which was left out of the merged PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened soft IOC system test robustness by implementing synchronous write operations with explicit wait directives to ensure proper test sequencing
  * Extended validation coverage to verify that readback field aliasing behaves correctly and consistently across all related system components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->