### PR TITLE
feat: allow aliased enum PVs to map values to underlying fastcs PVs

### DIFF
--- a/src/fastcs/demo/controllers.py
+++ b/src/fastcs/demo/controllers.py
@@ -95,6 +95,7 @@ class TemperatureController(Controller):
 
     async def connect(self) -> None:
         await self.connection.connect(self._settings.ip_settings)
+        self._connected = True
 
     async def reconnect(self):
         try:

--- a/src/fastcs/demo/schema.json
+++ b/src/fastcs/demo/schema.json
@@ -11,16 +11,16 @@
           "additionalProperties": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "boolean"
               },
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "number"
               },
               {
-                "type": "boolean"
+                "type": "string"
               }
             ]
           },

--- a/src/fastcs/demo/schema.json
+++ b/src/fastcs/demo/schema.json
@@ -1,11 +1,53 @@
 {
   "$defs": {
+    "EnumMapping": {
+      "additionalProperties": false,
+      "properties": {
+        "pv": {
+          "title": "Pv",
+          "type": "string"
+        },
+        "mapping": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "title": "Mapping",
+          "type": "object"
+        }
+      },
+      "required": [
+        "pv",
+        "mapping"
+      ],
+      "title": "EnumMapping",
+      "type": "object"
+    },
     "EpicsCAOptions": {
       "additionalProperties": false,
       "properties": {
         "aliases": {
           "additionalProperties": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/EnumMapping"
+              }
+            ]
           },
           "title": "Aliases",
           "type": "object"

--- a/src/fastcs/transports/epics/ca/ioc.py
+++ b/src/fastcs/transports/epics/ca/ioc.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections import Counter
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Mapping
 from enum import IntEnum
 from typing import Any, Literal, TypeVar
 
@@ -35,7 +35,7 @@ class EpicsCAIOC:
     def __init__(
         self,
         controller_apis: list[ControllerAPI],
-        aliases: dict[str, str | EnumMapping],
+        aliases: Mapping[str, str | EnumMapping],
     ):
         alias_pvs = [
             value if isinstance(value, str) else value.pv for value in aliases.values()
@@ -130,7 +130,7 @@ def _add_sub_controller_pvi_info(parent: ControllerAPI):
 
 
 def _create_and_link_attribute_pvs(
-    root_controller_api: ControllerAPI, aliases: dict[str, str | EnumMapping]
+    root_controller_api: ControllerAPI, aliases: Mapping[str, str | EnumMapping]
 ) -> None:
     for controller_api in root_controller_api.walk_api():
         pv_prefix = pv_prefix_from_path(controller_api.path)
@@ -157,7 +157,7 @@ def _create_and_link_attribute_pvs(
                 )
                 continue
 
-            alias = aliases.pop(f"{pv_prefix}:{pv_name}", None)
+            alias = aliases.get(f"{pv_prefix}:{pv_name}", None)
             match attribute:
                 case AttrRW():
                     if full_pv_name_length > (EPICS_MAX_NAME_LENGTH - 4):
@@ -168,7 +168,7 @@ def _create_and_link_attribute_pvs(
                         )
                         attribute.enabled = False
                     else:
-                        alias_rbv = aliases.pop(
+                        alias_rbv = aliases.get(
                             f"{pv_prefix}:{pv_name}{RBV_SUFFIX}", None
                         )
                         _create_and_link_read_pv(
@@ -203,21 +203,6 @@ def _create_and_link_attribute_pvs(
                     )
 
 
-def _make_in_record_and_add_callback(
-    pv: str, attribute: AttrR[DType_T]
-) -> RecordWrapper:
-    async def async_record_set(value: DType_T):
-        tracer.log_event(
-            "PV set from attribute", topic=attribute, pv=pv, value=repr(value)
-        )
-
-        record.set(cast_to_epics_type(attribute.datatype, value))
-
-    record = _make_in_record(pv, attribute)
-    attribute.add_on_update_callback(async_record_set)
-    return record
-
-
 def _create_and_link_read_pv(
     pv_prefix: str,
     pv_name: str,
@@ -227,7 +212,14 @@ def _create_and_link_read_pv(
 ) -> None:
     pv = f"{pv_prefix}:{pv_name}"
 
-    record = _make_in_record_and_add_callback(pv, attribute)
+    async def async_record_set(value: DType_T):
+        tracer.log_event(
+            "PV set from attribute", topic=attribute, pv=pv, value=repr(value)
+        )
+
+        record.set(cast_to_epics_type(attribute.datatype, value))
+
+    record = _make_in_record(pv, attribute)
 
     if isinstance(alias, str):
         _add_alias(record, alias)
@@ -236,17 +228,10 @@ def _create_and_link_read_pv(
         _add_read_enum_alias(alias, attribute, enum_attr)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "r")
+    attribute.add_on_update_callback(async_record_set)
 
 
-def _make_out_record_and_sync_setpoint(
-    pv: str, attribute: AttrW[DType_T]
-) -> RecordWrapper:
-    async def on_update(value):
-        logger.info("PV put: {pv} = {value}", pv=pv, value=repr(value))
-        await _run_and_set_alarm(
-            record, attribute.put(cast_from_epics_type(attribute.datatype, value))
-        )
-
+def _sync_setpoint(pv: str, attribute: AttrW[DType_T], record: RecordWrapper) -> None:
     async def set_setpoint_without_process(value: DType_T):
         tracer.log_event(
             "PV setpoint set from attribute", topic=attribute, pv=pv, value=repr(value)
@@ -254,9 +239,7 @@ def _make_out_record_and_sync_setpoint(
 
         record.set(cast_to_epics_type(attribute.datatype, value), process=False)
 
-    record = _make_out_record(pv, attribute, on_update=on_update)
     attribute.add_sync_setpoint_callback(set_setpoint_without_process)
-    return record
 
 
 def _create_and_link_write_pv(
@@ -268,7 +251,13 @@ def _create_and_link_write_pv(
 ):
     pv = f"{pv_prefix}:{pv_name}"
 
-    record = _make_out_record_and_sync_setpoint(pv, attribute)
+    async def on_update(value):
+        logger.info("PV put: {pv} = {value}", pv=pv, value=repr(value))
+        await _run_and_set_alarm(
+            record, attribute.put(cast_from_epics_type(attribute.datatype, value))
+        )
+
+    record = _make_out_record(pv, attribute, on_update=on_update)
 
     if isinstance(alias, str):
         _add_alias(record, alias)
@@ -277,17 +266,18 @@ def _create_and_link_write_pv(
         _add_write_enum_alias(alias, attribute, enum_attr)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "w")
+    _sync_setpoint(pv, attribute, record)
 
 
 def _create_and_link_command_pvs(
-    root_controller_api: ControllerAPI, aliases: dict[str, str | EnumMapping]
+    root_controller_api: ControllerAPI, aliases: Mapping[str, str | EnumMapping]
 ) -> None:
     for controller_api in root_controller_api.walk_api():
         pv_prefix = pv_prefix_from_path(controller_api.path)
 
         for attr_name, method in controller_api.command_methods.items():
             pv_name = snake_to_pascal(attr_name)
-            alias = aliases.pop(f"{pv_prefix}:{pv_name}", None)
+            alias = aliases.get(f"{pv_prefix}:{pv_name}", None)
 
             if len(f"{pv_prefix}:{pv_name}") > EPICS_MAX_NAME_LENGTH:
                 print(
@@ -385,7 +375,7 @@ def _set_alarm(record: RecordWrapper, alarm_state: int):
     )
 
 
-async def _run_and_set_alarm(record, coro: Awaitable):
+async def _run_and_set_alarm(record: RecordWrapper, coro: Awaitable):
     """Await `coro` and update `record`'s alarm state based on the outcome.
 
     On success, clears the alarm (NO_ALARM). On any exception, raises the
@@ -418,12 +408,15 @@ def _get_write_enum_attr_from_type(alias: EnumMapping):
 
 
 def _add_command_enum_alias(
-    alias: EnumMapping, method: Command, enum_attr: AttrW[EnumT]
+    alias: EnumMapping,
+    method: Command,
+    enum_attr: AttrW[EnumT],
 ):
-    record = _make_out_record_and_sync_setpoint(alias.pv, enum_attr)
-
-    async def trigger_command(_, value) -> None:
-        converted_value = alias.mapping.get(value.name)
+    async def trigger_command(value) -> None:
+        logger.info("PV put: {pv} = {value}", pv=alias.pv, value=repr(value))
+        cast_value = cast_from_epics_type(enum_attr.datatype, value)
+        await enum_attr.put(cast_value)
+        converted_value = alias.mapping.get(cast_value.name)
 
         if converted_value is None:
             logger.warning(
@@ -445,9 +438,11 @@ def _add_command_enum_alias(
 
         if converted_value:
             logger.info("Calling aliased command")
+            await enum_attr.put(value)
             await _run_and_set_alarm(record, method.fn())
 
-    enum_attr.set_on_put_callback(trigger_command)
+    record = _make_out_record(alias.pv, enum_attr, on_update=trigger_command)
+    _sync_setpoint(alias.pv, enum_attr, record)
 
 
 def _add_read_enum_alias(
@@ -456,6 +451,11 @@ def _add_read_enum_alias(
     enum = enum_attr.datatype.dtype
 
     async def convert_from_value(value) -> None:
+        tracer.log_event(
+            "PV set from attribute", topic=attribute, pv=alias.pv, value=repr(value)
+        )
+        record.set(cast_to_epics_type(enum_attr.datatype, value))
+
         converted_value = next(
             (k for k, v in alias.mapping.items() if v == value),
             None,
@@ -477,8 +477,8 @@ def _add_read_enum_alias(
                 mapping=alias.mapping,
             )
 
+    record = _make_in_record(alias.pv, enum_attr)
     attribute.add_on_update_callback(convert_from_value)
-    _make_in_record_and_add_callback(alias.pv, enum_attr)
 
 
 def _add_write_enum_alias(
@@ -486,10 +486,11 @@ def _add_write_enum_alias(
     attribute: AttrW[DType_T],
     enum_attr: AttrW[EnumT],
 ):
-    record = _make_out_record_and_sync_setpoint(alias.pv, enum_attr)
-
-    async def convert_to_value(_, value) -> None:
-        converted_value = alias.mapping.get(value.name)
+    async def convert_to_value(value) -> None:
+        logger.info("PV put: {pv} = {value}", pv=alias.pv, value=repr(value))
+        cast_value = cast_from_epics_type(enum_attr.datatype, value)
+        await enum_attr.put(cast_value)
+        converted_value = alias.mapping.get(cast_value.name)
 
         if converted_value is not None:
             logger.info(
@@ -511,4 +512,5 @@ def _add_write_enum_alias(
                 mapping=alias.mapping,
             )
 
-    enum_attr.set_on_put_callback(convert_to_value)
+    record = _make_out_record(alias.pv, enum_attr, on_update=convert_to_value)
+    _sync_setpoint(alias.pv, enum_attr, record)

--- a/src/fastcs/transports/epics/ca/ioc.py
+++ b/src/fastcs/transports/epics/ca/ioc.py
@@ -1,7 +1,8 @@
 import asyncio
 from collections import Counter
 from collections.abc import Awaitable
-from typing import Any, Literal
+from enum import IntEnum
+from typing import Any, Literal, TypeVar
 
 from softioc import alarm, builder, softioc
 from softioc.asyncio_dispatcher import AsyncioDispatcher
@@ -9,7 +10,7 @@ from softioc.pythonSoftIoc import RecordWrapper
 
 from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.controllers import ControllerAPI
-from fastcs.datatypes import DType_T, Waveform
+from fastcs.datatypes import DType_T, Enum, Waveform
 from fastcs.logging import logger
 from fastcs.methods import Command
 from fastcs.tracer import Tracer
@@ -19,20 +20,29 @@ from fastcs.transports.epics.ca.util import (
     cast_from_epics_type,
     cast_to_epics_type,
 )
+from fastcs.transports.epics.options import EnumMapping
 from fastcs.transports.epics.util import EPICS_MAX_NAME_LENGTH, pv_prefix_from_path
 from fastcs.util import snake_to_pascal
 
 tracer = Tracer()
-
+EnumT = TypeVar("EnumT", bound=IntEnum)
 RBV_SUFFIX = "_RBV"
 
 
 class EpicsCAIOC:
     """A softioc which handles one or more controllers."""
 
-    def __init__(self, controller_apis: list[ControllerAPI], aliases: dict[str, str]):
+    def __init__(
+        self,
+        controller_apis: list[ControllerAPI],
+        aliases: dict[str, str | EnumMapping],
+    ):
+        alias_pvs = [
+            value if isinstance(value, str) else value.pv for value in aliases.values()
+        ]
+
         if duplicate_aliases := [
-            alias for alias, count in Counter(aliases.values()).items() if count > 1
+            alias for alias, count in Counter(alias_pvs).items() if count > 1
         ]:
             raise RuntimeError(
                 "Failed to create EPICS CA IOC, as duplicate aliases were provided:"
@@ -120,7 +130,7 @@ def _add_sub_controller_pvi_info(parent: ControllerAPI):
 
 
 def _create_and_link_attribute_pvs(
-    root_controller_api: ControllerAPI, aliases: dict[str, str]
+    root_controller_api: ControllerAPI, aliases: dict[str, str | EnumMapping]
 ) -> None:
     for controller_api in root_controller_api.walk_api():
         pv_prefix = pv_prefix_from_path(controller_api.path)
@@ -147,7 +157,7 @@ def _create_and_link_attribute_pvs(
                 )
                 continue
 
-            alias = aliases.get(f"{pv_prefix}:{pv_name}", None)
+            alias = aliases.pop(f"{pv_prefix}:{pv_name}", None)
             match attribute:
                 case AttrRW():
                     if full_pv_name_length > (EPICS_MAX_NAME_LENGTH - 4):
@@ -158,7 +168,7 @@ def _create_and_link_attribute_pvs(
                         )
                         attribute.enabled = False
                     else:
-                        alias_rbv = aliases.get(
+                        alias_rbv = aliases.pop(
                             f"{pv_prefix}:{pv_name}{RBV_SUFFIX}", None
                         )
                         _create_and_link_read_pv(
@@ -193,15 +203,9 @@ def _create_and_link_attribute_pvs(
                     )
 
 
-def _create_and_link_read_pv(
-    pv_prefix: str,
-    pv_name: str,
-    attr_name: str,
-    alias: str | None,
-    attribute: AttrR[DType_T],
-) -> None:
-    pv = f"{pv_prefix}:{pv_name}"
-
+def _make_in_record_and_add_callback(
+    pv: str, attribute: AttrR[DType_T]
+) -> RecordWrapper:
     async def async_record_set(value: DType_T):
         tracer.log_event(
             "PV set from attribute", topic=attribute, pv=pv, value=repr(value)
@@ -210,23 +214,33 @@ def _create_and_link_read_pv(
         record.set(cast_to_epics_type(attribute.datatype, value))
 
     record = _make_in_record(pv, attribute)
-
-    _add_alias(record, alias)
-
-    _add_attr_pvi_info(record, pv_prefix, attr_name, "r")
-
     attribute.add_on_update_callback(async_record_set)
+    return record
 
 
-def _create_and_link_write_pv(
+def _create_and_link_read_pv(
     pv_prefix: str,
     pv_name: str,
     attr_name: str,
-    alias: str | None,
-    attribute: AttrW[DType_T],
-):
+    alias: str | EnumMapping | None,
+    attribute: AttrR[DType_T],
+) -> None:
     pv = f"{pv_prefix}:{pv_name}"
 
+    record = _make_in_record_and_add_callback(pv, attribute)
+
+    if isinstance(alias, str):
+        _add_alias(record, alias)
+    elif isinstance(alias, EnumMapping):
+        enum_attr = _get_read_enum_attr_from_type(alias)
+        _add_read_enum_alias(alias, attribute, enum_attr)
+
+    _add_attr_pvi_info(record, pv_prefix, attr_name, "r")
+
+
+def _make_out_record_and_sync_setpoint(
+    pv: str, attribute: AttrW[DType_T]
+) -> RecordWrapper:
     async def on_update(value):
         logger.info("PV put: {pv} = {value}", pv=pv, value=repr(value))
         await _run_and_set_alarm(
@@ -241,23 +255,39 @@ def _create_and_link_write_pv(
         record.set(cast_to_epics_type(attribute.datatype, value), process=False)
 
     record = _make_out_record(pv, attribute, on_update=on_update)
+    attribute.add_sync_setpoint_callback(set_setpoint_without_process)
+    return record
 
-    _add_alias(record, alias)
+
+def _create_and_link_write_pv(
+    pv_prefix: str,
+    pv_name: str,
+    attr_name: str,
+    alias: str | EnumMapping | None,
+    attribute: AttrW[DType_T],
+):
+    pv = f"{pv_prefix}:{pv_name}"
+
+    record = _make_out_record_and_sync_setpoint(pv, attribute)
+
+    if isinstance(alias, str):
+        _add_alias(record, alias)
+    elif isinstance(alias, EnumMapping):
+        enum_attr = _get_write_enum_attr_from_type(alias)
+        _add_write_enum_alias(alias, attribute, enum_attr)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "w")
 
-    attribute.add_sync_setpoint_callback(set_setpoint_without_process)
-
 
 def _create_and_link_command_pvs(
-    root_controller_api: ControllerAPI, aliases: dict[str, str]
+    root_controller_api: ControllerAPI, aliases: dict[str, str | EnumMapping]
 ) -> None:
     for controller_api in root_controller_api.walk_api():
         pv_prefix = pv_prefix_from_path(controller_api.path)
 
         for attr_name, method in controller_api.command_methods.items():
             pv_name = snake_to_pascal(attr_name)
-            alias = aliases.get(f"{pv_prefix}:{pv_name}", None)
+            alias = aliases.pop(f"{pv_prefix}:{pv_name}", None)
 
             if len(f"{pv_prefix}:{pv_name}") > EPICS_MAX_NAME_LENGTH:
                 print(
@@ -276,7 +306,11 @@ def _create_and_link_command_pvs(
 
 
 def _create_and_link_command_pv(
-    pv_prefix: str, pv_name: str, attr_name: str, alias: str | None, method: Command
+    pv_prefix: str,
+    pv_name: str,
+    attr_name: str,
+    alias: str | EnumMapping | None,
+    method: Command,
 ) -> None:
     pv = f"{pv_prefix}:{pv_name}"
 
@@ -293,7 +327,11 @@ def _create_and_link_command_pv(
         ONAM="Active",
     )
 
-    _add_alias(record, alias)
+    if isinstance(alias, str):
+        _add_alias(record, alias)
+    elif isinstance(alias, EnumMapping):
+        enum_attr = _get_write_enum_attr_from_type(alias)
+        _add_command_enum_alias(alias, method, enum_attr)
 
     _add_attr_pvi_info(record, pv_prefix, attr_name, "x")
 
@@ -360,3 +398,117 @@ async def _run_and_set_alarm(record, coro: Awaitable):
         _set_alarm(record, alarm.NO_ALARM)
     except Exception:
         _set_alarm(record, alarm.MAJOR_ALARM)
+
+
+def _get_enum_from_alias(
+    alias: EnumMapping,
+):
+    members = {name: i for i, name in enumerate(alias.mapping)}
+    return IntEnum("enum", members)
+
+
+def _get_read_enum_attr_from_type(alias: EnumMapping):
+    enum = _get_enum_from_alias(alias)
+    return AttrR(datatype=Enum(enum))
+
+
+def _get_write_enum_attr_from_type(alias: EnumMapping):
+    enum = _get_enum_from_alias(alias)
+    return AttrW(datatype=Enum(enum))
+
+
+def _add_command_enum_alias(
+    alias: EnumMapping, method: Command, enum_attr: AttrW[EnumT]
+):
+    record = _make_out_record_and_sync_setpoint(alias.pv, enum_attr)
+
+    async def trigger_command(_, value) -> None:
+        converted_value = alias.mapping.get(value.name)
+
+        if converted_value is None:
+            logger.warning(
+                "Failed to convert enum alias value {value} to command boolean. "
+                "No mapping exists.",
+                value=value,
+                enum_mapping=alias.mapping,
+            )
+            return
+
+        if not isinstance(converted_value, bool):
+            logger.warning(
+                "Aliased commands only accept boolean mappings. "
+                "Got {value} from mapping.",
+                value=converted_value,
+                enum_mapping=alias.mapping,
+            )
+            return
+
+        if converted_value:
+            logger.info("Calling aliased command")
+            await _run_and_set_alarm(record, method.fn())
+
+    enum_attr.set_on_put_callback(trigger_command)
+
+
+def _add_read_enum_alias(
+    alias: EnumMapping, attribute: AttrR[DType_T], enum_attr: AttrR[EnumT]
+):
+    enum = enum_attr.datatype.dtype
+
+    async def convert_from_value(value) -> None:
+        converted_value = next(
+            (k for k, v in alias.mapping.items() if v == value),
+            None,
+        )
+
+        if converted_value is not None:
+            validated_value = enum[converted_value]
+            logger.info(
+                "Converting to enum value {enum_value} from fastcs value {value}",
+                enum_value=validated_value,
+                value=value,
+            )
+            await enum_attr.update(validated_value)
+        else:
+            logger.warning(
+                "Ignoring enum update as fastcs value {value} has no "
+                "corresponding value in enum mapping",
+                value=value,
+                mapping=alias.mapping,
+            )
+
+    attribute.add_on_update_callback(convert_from_value)
+    _make_in_record_and_add_callback(alias.pv, enum_attr)
+
+
+def _add_write_enum_alias(
+    alias: EnumMapping,
+    attribute: AttrW[DType_T],
+    enum_attr: AttrW[EnumT],
+):
+    record = _make_out_record_and_sync_setpoint(alias.pv, enum_attr)
+
+    async def convert_to_value(_, value) -> None:
+        converted_value = alias.mapping.get(value.name)
+
+        if converted_value is not None:
+            logger.info(
+                "Converting enum value {enum_value} to fastcs value {converted_value}",
+                enum_value=value,
+                converted_value=converted_value,
+            )
+            await _run_and_set_alarm(
+                record,
+                attribute.put(
+                    cast_from_epics_type(attribute.datatype, converted_value)
+                ),
+            )
+        else:
+            logger.warning(
+                "Ignoring enum put value {value} as it has no "
+                "corresponding value in enum mapping",
+                value=value,
+                mapping=alias.mapping,
+            )
+
+    enum_attr.set_on_put_callback(convert_to_value)

--- a/src/fastcs/transports/epics/ca/ioc.py
+++ b/src/fastcs/transports/epics/ca/ioc.py
@@ -451,11 +451,6 @@ def _add_read_enum_alias(
     enum = enum_attr.datatype.dtype
 
     async def convert_from_value(value) -> None:
-        tracer.log_event(
-            "PV set from attribute", topic=attribute, pv=alias.pv, value=repr(value)
-        )
-        record.set(cast_to_epics_type(enum_attr.datatype, value))
-
         converted_value = next(
             (k for k, v in alias.mapping.items() if v == value),
             None,
@@ -463,6 +458,10 @@ def _add_read_enum_alias(
 
         if converted_value is not None:
             validated_value = enum[converted_value]
+            tracer.log_event(
+                "PV set from attribute", topic=attribute, pv=alias.pv, value=repr(value)
+            )
+            record.set(cast_to_epics_type(enum_attr.datatype, validated_value))
             logger.info(
                 "Converting to enum value {enum_value} from fastcs value {value}",
                 enum_value=validated_value,

--- a/src/fastcs/transports/epics/options.py
+++ b/src/fastcs/transports/epics/options.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, TypeAlias
 
 from pydantic import ConfigDict
+
+EnumMappingValue: TypeAlias = bool | int | float | str
 
 
 @dataclass
@@ -36,7 +38,7 @@ class EnumMapping:
     __pydantic_config__: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     pv: str
-    mapping: dict[str, int | str | float | bool]
+    mapping: dict[str, EnumMappingValue]
 
 
 @dataclass

--- a/src/fastcs/transports/epics/options.py
+++ b/src/fastcs/transports/epics/options.py
@@ -32,6 +32,14 @@ class EpicsGUIOptions:
 
 
 @dataclass
+class EnumMapping:
+    __pydantic_config__: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    pv: str
+    mapping: dict[str, int | str | float | bool]
+
+
+@dataclass
 class EpicsCAOptions:
     """Channel-Access-specific options.
 
@@ -41,7 +49,7 @@ class EpicsCAOptions:
 
     __pydantic_config__: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    aliases: dict[str, str] = field(default_factory=dict)
+    aliases: dict[str, str | EnumMapping] = field(default_factory=dict)
     """Mapping of fastcs PV names to their aliases.
 
     Setpoint and readback PVs must be aliased separately.

--- a/tests/data/schema.json
+++ b/tests/data/schema.json
@@ -11,16 +11,16 @@
           "additionalProperties": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "boolean"
               },
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "number"
               },
               {
-                "type": "boolean"
+                "type": "string"
               }
             ]
           },

--- a/tests/data/schema.json
+++ b/tests/data/schema.json
@@ -1,11 +1,53 @@
 {
   "$defs": {
+    "EnumMapping": {
+      "additionalProperties": false,
+      "properties": {
+        "pv": {
+          "title": "Pv",
+          "type": "string"
+        },
+        "mapping": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "title": "Mapping",
+          "type": "object"
+        }
+      },
+      "required": [
+        "pv",
+        "mapping"
+      ],
+      "title": "EnumMapping",
+      "type": "object"
+    },
     "EpicsCAOptions": {
       "additionalProperties": false,
       "properties": {
         "aliases": {
           "additionalProperties": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/EnumMapping"
+              }
+            ]
           },
           "title": "Aliases",
           "type": "object"

--- a/tests/example_softioc.py
+++ b/tests/example_softioc.py
@@ -61,6 +61,9 @@ def run(id="SOFTIOC_TEST_DEVICE"):
                         f"{id}:ChildVector:0:E": EnumMapping(
                             pv=f"{id}:EnumAliasE", mapping={"Off": 1, "On": 2}
                         ),
+                        f"{id}:ChildVector:0:E_RBV": EnumMapping(
+                            pv=f"{id}:EnumAliasE_RBV", mapping={"Off": 1, "On": 2}
+                        ),
                         f"{id}:ChildVector:0:D": EnumMapping(
                             pv=f"{id}:EnumAliasD",
                             mapping={"Idle": False, "Active": True},

--- a/tests/example_softioc.py
+++ b/tests/example_softioc.py
@@ -1,16 +1,24 @@
 import asyncio
+from enum import IntEnum
 from pathlib import Path
 
 from fastcs.attributes import AttrR, AttrRW, AttrW
 from fastcs.control_system import FastCS
 from fastcs.controllers import Controller, ControllerVector
-from fastcs.datatypes import Int
+from fastcs.datatypes import Enum, Int
 from fastcs.methods import command
 from fastcs.transports.epics.ca.transport import (
     EpicsCAOptions,
     EpicsCATransport,
     EpicsGUIOptions,
 )
+from fastcs.transports.epics.options import EnumMapping
+
+
+class ExampleEnum(IntEnum):
+    Invalid = 0
+    Idle = 1
+    Active = 2
 
 
 class ParentController(Controller):
@@ -33,6 +41,8 @@ class ChildController(Controller):
             self.fail_on_next_e = True
             print("D: FINISHED")
 
+    e: AttrRW = AttrRW(Enum(ExampleEnum))
+
 
 def run(id="SOFTIOC_TEST_DEVICE"):
     controller = ParentController()
@@ -48,6 +58,13 @@ def run(id="SOFTIOC_TEST_DEVICE"):
                     aliases={
                         f"{id}:B": f"{id}:AliasB",
                         f"{id}:B_RBV": f"{id}:AliasB_RBV",
+                        f"{id}:ChildVector:0:E": EnumMapping(
+                            pv=f"{id}:EnumAliasE", mapping={"Off": 1, "On": 2}
+                        ),
+                        f"{id}:ChildVector:0:D": EnumMapping(
+                            pv=f"{id}:EnumAliasD",
+                            mapping={"Idle": False, "Active": True},
+                        ),
                     }
                 ),
                 gui=gui_options,

--- a/tests/transports/epics/ca/test_softioc.py
+++ b/tests/transports/epics/ca/test_softioc.py
@@ -33,6 +33,7 @@ from fastcs.transports.epics.ca.util import (
     _make_in_record,
     _make_out_record,
 )
+from fastcs.transports.epics.options import EnumMapping
 from fastcs.transports.epics.util import EPICS_MAX_NAME_LENGTH
 
 DEVICE = "DEVICE"
@@ -43,6 +44,9 @@ SEVENTEEN_VALUES = [str(i) for i in range(1, 18)]
 class OnOffStates(enum.IntEnum):
     DISABLED = 0
     ENABLED = 1
+
+
+async def do_nothing(): ...
 
 
 @pytest.mark.asyncio
@@ -146,6 +150,58 @@ async def test_ioc_raises_if_duplicate_aliases_provided(mocker: MockerFixture):
         RuntimeError, match=re.escape("duplicate aliases were provided: ['Alias']")
     ):
         EpicsCAIOC(mocker.MagicMock(), aliases)
+
+
+@pytest.mark.parametrize(
+    ("create_pv", "add_helper", "expected_type", "mock_attribute"),
+    [
+        (
+            _create_and_link_write_pv,
+            "_add_write_enum_alias",
+            AttrW,
+            AttrRW(Int()),
+        ),
+        (
+            _create_and_link_command_pv,
+            "_add_command_enum_alias",
+            AttrW,
+            Command(do_nothing),
+        ),
+        (
+            _create_and_link_read_pv,
+            "_add_read_enum_alias",
+            AttrR,
+            AttrR(Int()),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_and_link_pv_adds_enum_mapping(
+    mocker: MockerFixture,
+    create_pv,
+    add_helper: str,
+    expected_type: type[AttrW] | type[AttrR],
+    mock_attribute: AttrRW | AttrR | Command,
+):
+    add_enum_alias = mocker.patch(f"fastcs.transports.epics.ca.ioc.{add_helper}")
+    enum_mapping = EnumMapping(pv="enum_alias", mapping={"One": 1, "Two": 2})
+
+    create_pv(
+        "PREFIX",
+        "PV",
+        "attr",
+        enum_mapping,
+        mock_attribute,
+    )
+
+    add_enum_alias.assert_called_once()
+    alias, passed_attribute, enum_attr = add_enum_alias.call_args.args
+
+    assert alias == enum_mapping
+    assert passed_attribute == mock_attribute
+    assert isinstance(enum_attr, expected_type)
+    assert isinstance(enum_attr.datatype, Enum)
+    assert enum_attr.datatype.names == ["One", "Two"]
 
 
 @pytest.mark.parametrize(
@@ -567,9 +623,6 @@ def test_add_attr_pvi_info(mocker: MockerFixture):
             }
         },
     )
-
-
-async def do_nothing(): ...
 
 
 class ControllerLongNames(Controller):

--- a/tests/transports/epics/ca/test_softioc_system.py
+++ b/tests/transports/epics/ca/test_softioc_system.py
@@ -44,6 +44,10 @@ def test_ioc(softioc_subprocess: tuple[str, Queue]):
     assert child_pvi["value"] == {
         "c": {"w": f"{pv_prefix}:ChildVector:0:C"},
         "d": {"x": f"{pv_prefix}:ChildVector:0:D"},
+        "e": {
+            "r": f"{pv_prefix}:ChildVector:0:E_RBV",
+            "w": f"{pv_prefix}:ChildVector:0:E",
+        },
     }
 
     # Assert alias. Aliases do not show up in PVI structure
@@ -54,7 +58,35 @@ def test_ioc(softioc_subprocess: tuple[str, Queue]):
     assert ctxt.get(f"{pv_prefix}:B") == 20
     assert ctxt.get(f"{pv_prefix}:B_RBV") == ctxt.get(f"{pv_prefix}:AliasB_RBV") == 20
 
+    # Assert enum alias. Enum aliases do not show up in PVI structure
+    enum_value = ctxt.get(f"{pv_prefix}:ChildVector:0:E")
+    assert enum_value == 0
+    assert str(enum_value) == "Invalid"  # Default for underlying enum attr
+    aliased_enum_value = ctxt.get(f"{pv_prefix}:EnumAliasE")
+    assert aliased_enum_value == 0
+    assert str(aliased_enum_value) == "Off"  # Default for alias enum attr
+
+    ctxt.put(f"{pv_prefix}:EnumAliasE", 1, wait=True)
+    assert (
+        str(ctxt.get(f"{pv_prefix}:EnumAliasE")) == "On"
+    )  # 'On' is index 1, but maps to value '2'
+    converted_enum_value = ctxt.get(f"{pv_prefix}:ChildVector:0:E")
+    assert converted_enum_value == 2  # Underlying enum attr gets put with 2
+    assert str(converted_enum_value) == "Active"
+    assert str(ctxt.get(f"{pv_prefix}:ChildVector:0:E_RBV")) == "Active"
+
     # Assert command exceptions set record alarm states
     ctxt.put(f"{pv_prefix}:ChildVector:0:D", True, wait=True)
-    d_alarm = ctxt.get(f"{pv_prefix}:ChildVector:0:D.SEVR")
-    assert d_alarm == alarm.MAJOR_ALARM
+    assert ctxt.get(f"{pv_prefix}:ChildVector:0:D.SEVR") == alarm.MAJOR_ALARM
+    ctxt.put(f"{pv_prefix}:ChildVector:0:D", True, wait=True)
+    assert (
+        ctxt.get(f"{pv_prefix}:ChildVector:0:D.SEVR") == alarm.NO_ALARM
+    )  # Second put resets alarm
+
+    # Assert command aliased to enum
+    ctxt.put(
+        f"{pv_prefix}:EnumAliasD", "Active", wait=True
+    )  # This aliases to True on command 'D'
+    assert ctxt.get(f"{pv_prefix}:EnumAliasD.SEVR") == alarm.MAJOR_ALARM
+    ctxt.put(f"{pv_prefix}:EnumAliasD", "Active", wait=True)
+    assert ctxt.get(f"{pv_prefix}:EnumAliasD.SEVR") == alarm.NO_ALARM

--- a/tests/transports/epics/ca/test_softioc_system.py
+++ b/tests/transports/epics/ca/test_softioc_system.py
@@ -75,6 +75,12 @@ def test_ioc(softioc_subprocess: tuple[str, Queue]):
     assert str(converted_enum_value) == "Active"
     assert str(ctxt.get(f"{pv_prefix}:ChildVector:0:E_RBV")) == "Active"
 
+    ctxt.put(f"{pv_prefix}:ChildVector:0:E", 1, wait=True)
+    assert str(ctxt.get(f"{pv_prefix}:ChildVector:0:E_RBV")) == "Idle"
+    assert (
+        str(ctxt.get(f"{pv_prefix}:EnumAliasE_RBV")) == "Off"
+    )  # Aliased enum gets converted update
+
     # Assert command exceptions set record alarm states
     ctxt.put(f"{pv_prefix}:ChildVector:0:D", True, wait=True)
     assert ctxt.get(f"{pv_prefix}:ChildVector:0:D.SEVR") == alarm.MAJOR_ALARM


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EPICS aliases backed by enum mappings.
  * Enum mappings now translate read, write, and command values between EPICS and application fields.
  * Added validation and alarm handling for unmapped or invalid enum values.
* **Bug Fixes**
  * Connection state now correctly reports success after connecting.
  * Successful commands clear previously raised alarms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->